### PR TITLE
Remove envsubst step in datafeeder deployment

### DIFF
--- a/templates/datafeeder/datafeeder-deployment.yaml
+++ b/templates/datafeeder/datafeeder-deployment.yaml
@@ -26,19 +26,6 @@ spec:
         "kubernetes.io/os": linux
       initContainers:
       {{- include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
-      {{- if .Values.georchestra.webapps.datafeeder.envsubst.enabled }}
-      - name: envsubst
-        image: georchestra/k8s-initcontainer-envsubst
-        volumeMounts:
-        - mountPath: /etc/georchestra
-          name: georchestra-datadir
-        env:
-          - name: DEBUG
-            value: "yes"
-          - name: SUBST_FILES
-            value: "/etc/georchestra/datafeeder/frontend-config.json"
-          {{- include "georchestra.common-envs" . | nindent 10 }}
-      {{- end }}
 
       containers:
       - name: georchestra-datafeeder

--- a/values.yaml
+++ b/values.yaml
@@ -29,8 +29,6 @@ georchestra:
       # - name: SMTPPORT
       #   value: "25"
       #registry_secret: default
-      envsubst:
-        enabled: true
     datafeeder_frontend:
       # Matches datafeeder/import-xxx.yaml templates in the helm chart
       enabled: true # won't deploy if datafeeder is not enable


### PR DESCRIPTION
The `georchestra/k8s-initcontainer-envsubst` image was used to allow using env variables in the `datafeeder/frontend-config.json` file. This proved to do more harm than good since:
* this file contains a `thesaurusUrl` template value with tokens such as `${q}` and `${lang}`, which were simply removed by envsubst
* env variables should not be needed in this file anyway, since URL can be expressed as relative paths instead of absolue

This PR is a proposal to remove this step altogether.