### PR TITLE
Openldap config: fix #40

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -111,10 +111,6 @@ Insert LDAP environment variables
 */}}
 {{- define "georchestra.ldap-envs" -}}
 {{- $ldap := .Values.ldap -}}
-{{- $ldap_secret_georchestra_name := printf "%s-ldap-passwords-secret" (include "georchestra.fullname" .) -}}
-{{- if $ldap.existingSecret }}
-{{- $ldap_secret_georchestra_name = $ldap.existingSecret -}}
-{{- end }}
 {{- if .Values.georchestra.webapps.openldap.enabled }}
 - name: LDAPHOST
   value: "{{ include "georchestra.fullname" . }}-ldap-svc"
@@ -133,7 +129,7 @@ Insert LDAP environment variables
 - name: LDAPADMINPASSWORD
   valueFrom:
     secretKeyRef:
-      name: {{ $ldap_secret_georchestra_name }}
+      name: {{ $ldap.existingSecret | default (printf "%s-ldap-passwords-secret" (include "georchestra.fullname" .)) }}
       key: SLAPD_PASSWORD
       optional: false
 - name: LDAPUSERSRDN

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -111,6 +111,10 @@ Insert LDAP environment variables
 */}}
 {{- define "georchestra.ldap-envs" -}}
 {{- $ldap := .Values.ldap -}}
+{{- $ldap_secret_georchestra_name := printf "%s-ldap-passwords-secret" (include "georchestra.fullname" .) -}}
+{{- if $ldap.existingSecret }}
+{{- $ldap_secret_georchestra_name = $ldap.existingSecret -}}
+{{- end }}
 {{- if .Values.georchestra.webapps.openldap.enabled }}
 - name: LDAPHOST
   value: "{{ include "georchestra.fullname" . }}-ldap-svc"
@@ -127,7 +131,11 @@ Insert LDAP environment variables
 - name: LDAPADMINDN
   value: "{{ $ldap.adminDn }}"
 - name: LDAPADMINPASSWORD
-  value: "{{ $ldap.adminPassword }}"
+  valueFrom:
+    secretKeyRef:
+      name: {{ $ldap_secret_georchestra_name }}
+      key: SLAPD_PASSWORD
+      optional: false
 - name: LDAPUSERSRDN
   value: "{{ $ldap.usersRdn }}"
 - name: LDAPROLESRDN

--- a/templates/ldap/openldap-deployment.yaml
+++ b/templates/ldap/openldap-deployment.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.georchestra.webapps.openldap.enabled -}}
 {{- $webapp := .Values.georchestra.webapps.openldap -}}
-{{- $ldap_secret_georchestra_name := printf "%s-ldap-passwords-secret" (include "georchestra.fullname" .) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -47,7 +46,7 @@ spec:
         # Load the ldap admin password from a secret. Can also allow to override some other env vars with env vars defined in this secret, like for instance the GEORCHESTRA_PRIVILEGED_USER_PASSWORD
         envFrom:
           - secretRef:
-              name: {{ .Values.ldap.existingSecret | default $ldap_secret_georchestra_name | quote }}
+              name: {{ .Values.ldap.existingSecret | default (printf "%s-ldap-passwords-secret" (include "georchestra.fullname" .)) | quote }}
         ports:
         - containerPort: {{ .Values.ldap.port }}
           name: ldap

--- a/templates/ldap/openldap-deployment.yaml
+++ b/templates/ldap/openldap-deployment.yaml
@@ -45,6 +45,12 @@ spec:
           {{- if $webapp.extra_environment }}
           {{- $webapp.extra_environment | toYaml | nindent 10 }}
           {{- end }}
+        {{- with .Values.ldap.existingSecret }}
+        # Override some env vars with env vars defined in this secret, like for instance the ldapadmin password
+        envFrom:
+          - secretRef:
+              name: {{ . }}
+        {{- end }}
         ports:
         - containerPort: {{ .Values.ldap.port }}
           name: ldap

--- a/templates/ldap/openldap-deployment.yaml
+++ b/templates/ldap/openldap-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           - name: SLAPD_DOMAIN
             value: georchestra.org
           - name: SLAPD_PASSWORD
-            value: secret
+            value: {{ .Values.ldap.adminPassword }}
           - name: RUN_AS_UID
             value: "0"
           - name: RUN_AS_GID
@@ -46,7 +46,7 @@ spec:
           {{- $webapp.extra_environment | toYaml | nindent 10 }}
           {{- end }}
         ports:
-        - containerPort: 389
+        - containerPort: {{ .Values.ldap.port }}
           name: ldap
         volumeMounts:
           - mountPath: /etc/ldap
@@ -58,9 +58,9 @@ spec:
             command:
             - ldapsearch
             - -x
-            - -Hldap://localhost:389/
-            - -bdc=georchestra,dc=org
-            - cn=admin,dc=georchestra,dc=org
+            - -Hldap://localhost:{{ .Values.ldap.port }}/
+            - -b{{ .Values.ldap.baseDn }}
+            - {{ .Values.ldap.adminDn }}
           initialDelaySeconds: 30
       volumes:
       - name: openldap-data

--- a/templates/ldap/openldap-deployment.yaml
+++ b/templates/ldap/openldap-deployment.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.georchestra.webapps.openldap.enabled -}}
 {{- $webapp := .Values.georchestra.webapps.openldap -}}
+{{- $ldap_secret_georchestra_name := printf "%s-ldap-passwords-secret" (include "georchestra.fullname" .) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -36,8 +37,6 @@ spec:
             value: georchestra
           - name: SLAPD_DOMAIN
             value: georchestra.org
-          - name: SLAPD_PASSWORD
-            value: {{ .Values.ldap.adminPassword }}
           - name: RUN_AS_UID
             value: "0"
           - name: RUN_AS_GID
@@ -45,12 +44,10 @@ spec:
           {{- if $webapp.extra_environment }}
           {{- $webapp.extra_environment | toYaml | nindent 10 }}
           {{- end }}
-        {{- with .Values.ldap.existingSecret }}
-        # Override some env vars with env vars defined in this secret, like for instance the ldapadmin password
+        # Load the ldap admin password from a secret. Can also allow to override some other env vars with env vars defined in this secret, like for instance the GEORCHESTRA_PRIVILEGED_USER_PASSWORD
         envFrom:
           - secretRef:
-              name: {{ . }}
-        {{- end }}
+              name: {{ .Values.ldap.existingSecret | default $ldap_secret_georchestra_name | quote }}
         ports:
         - containerPort: {{ .Values.ldap.port }}
           name: ldap

--- a/templates/ldap/openldap-passwords-secret.yaml
+++ b/templates/ldap/openldap-passwords-secret.yaml
@@ -1,0 +1,11 @@
+{{- if (not .Values.ldap.existingSecret ) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "georchestra.fullname" . }}-ldap-passwords-secret
+  labels:
+    {{- include "georchestra.labels" . | nindent 4 }}
+type: Opaque
+data:
+  SLAPD_PASSWORD: {{ .Values.ldap.adminPassword | b64enc | quote }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -194,7 +194,9 @@ ldap:
   adminDn: "cn=admin,dc=georchestra,dc=org"
   rolesRdn: "ou=roles"
   orgsRdn: "ou=orgs"
-  # You can override in this secret some sensitive env. vars, like the ldap admin password
+  # By default, a secret is automatically created with the password declared above.
+  # You can override this by using an existingSecret declaring some environment variables
+  # and that should at least declare the ldap admin password
   # Example of valid secret content (limited to the data part) would be
   # "data": {
   #     "SLAPD_PASSWORD": "mysecretldapadminpasswor_base64encoded"

--- a/values.yaml
+++ b/values.yaml
@@ -194,11 +194,13 @@ ldap:
   adminDn: "cn=admin,dc=georchestra,dc=org"
   rolesRdn: "ou=roles"
   orgsRdn: "ou=orgs"
-  # You can override in this secret some sensitive env. vars, like the adminPassword
-  # Example of valid secret content (limited to the data part) would be 
+  # You can override in this secret some sensitive env. vars, like the ldap admin password
+  # Example of valid secret content (limited to the data part) would be
   # "data": {
-  #     "SLAPD_PASSWORD": "mysecretldapadminpassword"
+  #     "SLAPD_PASSWORD": "mysecretldapadminpasswor_base64encoded"
   # },
+  # Optionally, you can also provide the GEORCHESTRA_PRIVILEGED_USER_PASSWORD env var, that will
+  # be used to replace the default one on first run, see https://github.com/georchestra/georchestra/blob/master/ldap/docker-root/docker-entrypoint.d/01-populate#L47-L54
   # existingSecret: mysecretldapenvvars
 
 database:

--- a/values.yaml
+++ b/values.yaml
@@ -194,6 +194,12 @@ ldap:
   adminDn: "cn=admin,dc=georchestra,dc=org"
   rolesRdn: "ou=roles"
   orgsRdn: "ou=orgs"
+  # You can override in this secret some sensitive env. vars, like the adminPassword
+  # Example of valid secret content (limited to the data part) would be 
+  # "data": {
+  #     "SLAPD_PASSWORD": "mysecretldapadminpassword"
+  # },
+  # existingSecret: mysecretldapenvvars
 
 database:
   builtin: true


### PR DESCRIPTION
- read the configuration from chart's values file(s)
- support passing the password (and possibly other env var alongside) using a secret 

Example of valid secret could be 
```
apiVersion: v1
kind: Secret
metadata:
  name: myldapsecret
type: Opaque
data:
  SLAPD_PASSWORD: "bXlzZWNyZXRsZGFwYWRtaW5wYXNzd29yZA=="
```
where the value is the actual password  base64 encoded  (`echo -n 'mysecretldapadminpassword' | base64`) 