### PR TITLE
[DB] Fix builtin DB init script. Document the DB existingSecret  params

### DIFF
--- a/templates/database/database-configmap-init.yaml
+++ b/templates/database/database-configmap-init.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.database.builtin -}}
+{{- $geodata := .Values.database.geodata -}}
+{{- $df := .Values.database.datafeeder -}}
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,12 +10,15 @@ metadata:
     {{- include "georchestra.labels" . | nindent 4 }}
 data:
   00_init.sql: |-
-    create database geodata;
-    grant all privileges on database geodata to georchestra;
-    create database datafeeder;
-    grant all privileges on database datafeeder to georchestra;
-    \c datafeeder;
+    create database {{ $geodata.auth.database | quote }};
+    create user {{ $geodata.auth.username | quote }} with ENCRYPTED PASSWORD '{{ $geodata.auth.password }}';
+    grant all privileges on database {{ $geodata.auth.database | quote }} to {{ $geodata.auth.username | quote }};
+    create database {{ $df.auth.database | quote }};
+    create user {{ $df.auth.username | quote }} with ENCRYPTED PASSWORD '{{ $df.auth.password }}';
+    grant all privileges on database {{ $df.auth.database | quote }} to {{ $df.auth.username | quote }};
+    grant all privileges on database {{ $df.auth.database | quote }} to georchestra;
+    \c {{ $df.auth.database | quote }};
     CREATE SCHEMA datafeeder;
     CREATE SEQUENCE datafeeder.hibernate_sequence;
-    GRANT ALL ON datafeeder.hibernate_sequence TO georchestra;
+    GRANT ALL ON datafeeder.hibernate_sequence TO {{ $df.auth.username | quote }};
 {{- end }}

--- a/templates/database/database-configmap-init.yaml
+++ b/templates/database/database-configmap-init.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "georchestra.fullname" . }}-database-init
+  name: {{ .Release.Name }}-database-init
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
 data:

--- a/values.yaml
+++ b/values.yaml
@@ -215,13 +215,13 @@ database:
     tag: latest
   auth:
     database: georchestra
-    # If using an existing secret: this one will both be used by the bitnami chart managing the DB 
-    # and by the georchestra db secret 
-    # (https://github.com/georchestra/helm-georchestra/blob/main/templates/database/database-georchestra-secret.yaml) 
+    # If using an existing secret: this one will both be used by the bitnami chart managing the DB
+    # and by the georchestra db secret
+    # (https://github.com/georchestra/helm-georchestra/blob/main/templates/database/database-georchestra-secret.yaml)
     # that is used by the apps
     # So you must be quite careful. It should follow the pattern from the previsouly mentioned secret
     # and tell the bitnami chart which variable provide the user and password
-    # And the `database`, `username` and `ssl` params still have to be defined here and match the ones 
+    # And the `database`, `username` and `ssl` params still have to be defined here and match the ones
     # provided by the secret
     # existingSecret: mysecret
     # secretKeys:
@@ -248,9 +248,9 @@ database:
   geodata:
     auth:
       database: geodata
-      # If using the builtin database, you cannot use an existingSecret configuration: the init script (see above) 
+      # If using the builtin database, you cannot use an existingSecret configuration: the init script (see above)
       # is only able to use the basic yaml params.
-      # If using an existing secret: this one will need to match the pattern followed by 
+      # If using an existing secret: this one will need to match the pattern followed by
       # https://github.com/georchestra/helm-georchestra/blob/main/templates/database/database-geodata-secret.yaml
       # The other configuration params will not be used.
       # existingSecret: mysecret
@@ -262,9 +262,9 @@ database:
   datafeeder:
     auth:
       database: datafeeder
-      # If using the builtin database, you cannot use an existingSecret configuration: the init script (see above) 
+      # If using the builtin database, you cannot use an existingSecret configuration: the init script (see above)
       # is only able to use the basic yaml params.
-      # If using an existing secret: this one will need to match the pattern followed by 
+      # If using an existing secret: this one will need to match the pattern followed by
       # https://github.com/georchestra/helm-georchestra/blob/main/templates/database/database-datafeeder-secret.yaml
       # The other configuration params will not be used.
       # existingSecret: mysecret

--- a/values.yaml
+++ b/values.yaml
@@ -215,7 +215,18 @@ database:
     tag: latest
   auth:
     database: georchestra
-#   existingSecret: mysecret
+    # If using an existing secret: this one will both be used by the bitnami chart managing the DB 
+    # and by the georchestra db secret 
+    # (https://github.com/georchestra/helm-georchestra/blob/main/templates/database/database-georchestra-secret.yaml) 
+    # that is used by the apps
+    # So you must be quite careful. It should follow the pattern from the previsouly mentioned secret
+    # and tell the bitnami chart which variable provide the user and password
+    # And the `database`, `username` and `ssl` params still have to be defined here and match the ones 
+    # provided by the secret
+    # existingSecret: mysecret
+    # secretKeys:
+    #   adminPasswordKey: postgresPassword
+    #   userPasswordKey: password # This one should stay as it is
 #   host: georchestra
     password: georchestra
     postgresPassword: georchestra
@@ -237,6 +248,11 @@ database:
   geodata:
     auth:
       database: geodata
+      # If using the builtin database, you cannot use an existingSecret configuration: the init script (see above) 
+      # is only able to use the basic yaml params.
+      # If using an existing secret: this one will need to match the pattern followed by 
+      # https://github.com/georchestra/helm-georchestra/blob/main/templates/database/database-geodata-secret.yaml
+      # The other configuration params will not be used.
       # existingSecret: mysecret
       host: geodata
       password: geodata
@@ -246,6 +262,11 @@ database:
   datafeeder:
     auth:
       database: datafeeder
+      # If using the builtin database, you cannot use an existingSecret configuration: the init script (see above) 
+      # is only able to use the basic yaml params.
+      # If using an existing secret: this one will need to match the pattern followed by 
+      # https://github.com/georchestra/helm-georchestra/blob/main/templates/database/database-datafeeder-secret.yaml
+      # The other configuration params will not be used.
       # existingSecret: mysecret
       host: datafeeder
       port: "5432"


### PR DESCRIPTION
**Init Script:**
- **Fix #48**: 
name of init script should match the one provided [in values.yaml](https://github.com/georchestra/helm-georchestra/blob/main/values.yaml#L233)

- **_In case of Builtin DBs:_**
Init script was giving ownership of all DBs to georchestra user, no using the config params for geodata and datafeeder DBs. Which were nevertheless used by the geodata and datafeeder connection secrets. So for instance datafeeder was trying to connect with `datafeeder` user, but it had not been created.
This way, the init script actually creates the users and gives them ownership on their respective DB

**Documentation**: 
clarify the usage of the existingSecret params