### PR TITLE
Conform all the imagePullPolicy for the prepare containers

### DIFF
--- a/templates/geonetwork/geonetwork-deployment.yaml
+++ b/templates/geonetwork/geonetwork-deployment.yaml
@@ -40,6 +40,7 @@ spec:
       {{ include "georchestra.bootstrap_georchestra_datadir" $ | nindent 6 }}
       - name: prepare-geonetwork-webapp
         image: {{ $webapp.docker_image }}
+        imagePullPolicy: Always
         command:
         - /bin/sh
         - -c

--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -43,6 +43,7 @@ spec:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       - name: prepare-geoserver-webapp
         image: {{ $webapp.docker_image }}
+        imagePullPolicy: Always
         command:
         - /bin/sh
         - -c

--- a/templates/security-proxy/security-proxy-deployment.yaml
+++ b/templates/security-proxy/security-proxy-deployment.yaml
@@ -52,6 +52,7 @@ spec:
       {{- end }}
       - name: prepare-proxy-webapp
         image: {{ $webapp.docker_image }}
+        imagePullPolicy: Always
         command:
           - /bin/sh
           - -c


### PR DESCRIPTION
The "prepare containers" do not have the same imagePullPolicy as the actual main container.

This is an issue as we need the latest docker image especially when using the "latest" docker image tag.