### PR TITLE
geoserver - adding fqdn to the geoserver's CSRF whitelist

### DIFF
--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -191,6 +191,8 @@ spec:
                 name: {{ $database_secret_gwc_name }}
                 key: password
                 optional: false
+          - name: GEOSERVER_CSRF_WHITELIST
+            value: {{ .Values.fqdn }}
           {{- include "georchestra.database-georchestra-envs" . | nindent 10 }}
           {{- if $webapp.extra_environment }}
           {{- $webapp.extra_environment | toYaml | nindent 10 }}


### PR DESCRIPTION
See https://docs.geoserver.org/main/en/user/security/webadmin/csrf.html for the motivation.

Also please note that in case of using the geOrchestra gateway, the default http header for the referrer-policy will be "no-referrer", which prevents wicket to determine if the request is legit or not (the check is based on the referer or origin http headers). so to make sure the referer header is provided, this requires the following configuration property to be set on the gateway as well:

```
spring.cloud.gateway.filter.secure-headers=strict-origin (or something
  laxer than no-referrer, see mdn doc for possible values)
```

Note: I wonder if one needs to customize the value, maybe we need another value in the values.yaml ?
