### PR TITLE
add ability to set extra containers volumes to ldap

### DIFF
--- a/templates/ldap/openldap-deployment.yaml
+++ b/templates/ldap/openldap-deployment.yaml
@@ -28,6 +28,9 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       containers:
+      {{- if $webapp.extraContainers }}
+        {{ toYaml $webapp.extraContainers | nindent 6 }}
+      {{- end }}
       - name: georchestra-ldap
         image: {{ $webapp.docker_image }}
         imagePullPolicy: Always
@@ -81,8 +84,5 @@ spec:
       imagePullSecrets:
       - name: {{ $webapp.registry_secret }}
       {{- end }}
-    {{- if $webapp.extraContainers }}
-      {{ toYaml $webapp.extraContainers | nindent 6 }}
-    {{- end }}
 
 {{- end }}

--- a/templates/ldap/openldap-deployment.yaml
+++ b/templates/ldap/openldap-deployment.yaml
@@ -55,6 +55,9 @@ spec:
             name: openldap-config
           - mountPath: /var/lib/ldap
             name: openldap-data
+          {{- if $webapp.extraVolumes }}
+            {{- toYaml $webapp.extraVolumes | nindent 10 }}
+          {{- end }}
         livenessProbe:
           exec:
             command:
@@ -71,9 +74,15 @@ spec:
       - name: openldap-config
         persistentVolumeClaim:
           claimName: {{ include "georchestra.fullname" . }}-openldap-config
+      {{- if $webapp.extraVolumeMounts }}
+          {{- toYaml $webapp.extraVolumeMounts | nindent 6 }}
+      {{- end }}
       {{- if $webapp.registry_secret }}
       imagePullSecrets:
       - name: {{ $webapp.registry_secret }}
       {{- end }}
+    {{- if $webapp.extraContainers }}
+      {{ toYaml $webapp.extraContainers | nindent 6 }}
+    {{- end }}
 
 {{- end }}

--- a/templates/ldap/openldap-deployment.yaml
+++ b/templates/ldap/openldap-deployment.yaml
@@ -58,8 +58,8 @@ spec:
             name: openldap-config
           - mountPath: /var/lib/ldap
             name: openldap-data
-          {{- if $webapp.extraVolumes }}
-            {{- toYaml $webapp.extraVolumes | nindent 10 }}
+          {{- if $webapp.extraVolumeMounts }}
+            {{- toYaml $webapp.extraVolumeMounts | nindent 10 }}
           {{- end }}
         livenessProbe:
           exec:
@@ -77,8 +77,8 @@ spec:
       - name: openldap-config
         persistentVolumeClaim:
           claimName: {{ include "georchestra.fullname" . }}-openldap-config
-      {{- if $webapp.extraVolumeMounts }}
-          {{- toYaml $webapp.extraVolumeMounts | nindent 6 }}
+      {{- if $webapp.extraVolumes }}
+          {{- toYaml $webapp.extraVolumes | nindent 6 }}
       {{- end }}
       {{- if $webapp.registry_secret }}
       imagePullSecrets:

--- a/values.yaml
+++ b/values.yaml
@@ -104,6 +104,15 @@ georchestra:
     openldap:
       enabled: true
       docker_image: georchestra/ldap:latest
+      extraVolumeMounts: []
+      #  - name: copy-portal-skins
+      #   mountPath: /var/lib/lemonldap-ng/portal/skins
+      extraVolumes: []
+      #  - name: copy-portal-skins
+      #    emptyDir: {}
+      extraContainers:
+      #  - name: my-sidecar
+      #    image: nginx:latest
       # registry_secret: default
     proxy:
       enabled: true


### PR DESCRIPTION
This adds the ability to set extra containers and volumes for ldap.
Example use case are:
- adding saslauthd alongside with ldap