### PR TITLE
keep pvc resources by default

### DIFF
--- a/templates/geonetwork/elasticsearch/es-data-pvc.yaml
+++ b/templates/geonetwork/elasticsearch/es-data-pvc.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gn4-elasticsearch
+    helm.sh/resource-policy: "keep"
 spec:
   accessModes:
   - ReadWriteOnce

--- a/templates/geonetwork/geonetwork-datadir-pvc.yaml
+++ b/templates/geonetwork/geonetwork-datadir-pvc.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geonetwork
+    helm.sh/resource-policy: "keep"
 spec:
   accessModes:
   - ReadWriteOnce

--- a/templates/geoserver/geoserver-datadir-pvc.yaml
+++ b/templates/geoserver/geoserver-datadir-pvc.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geoserver
+    helm.sh/resource-policy: "keep"
 spec:
   accessModes:
   - ReadWriteOnce

--- a/templates/geoserver/geoserver-geodata-pvc.yaml
+++ b/templates/geoserver/geoserver-geodata-pvc.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geoserver
+    helm.sh/resource-policy: "keep"
 spec:
   accessModes:
   - ReadWriteOnce

--- a/templates/geoserver/geoserver-tiles-pvc.yaml
+++ b/templates/geoserver/geoserver-tiles-pvc.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geoserver
+    helm.sh/resource-policy: "keep"
 spec:
   accessModes:
   - ReadWriteOnce

--- a/templates/ldap/openldap-pvc.yaml
+++ b/templates/ldap/openldap-pvc.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-ldap
+    helm.sh/resource-policy: "keep"
 spec:
   accessModes:
   - ReadWriteOnce
@@ -26,6 +27,7 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-ldap
+    helm.sh/resource-policy: "keep"
 spec:
   accessModes:
   - ReadWriteOnce

--- a/templates/mapstore/mapstore-pvc.yaml
+++ b/templates/mapstore/mapstore-pvc.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-mapstore
+    helm.sh/resource-policy: "keep"
 spec:
   accessModes:
   - ReadWriteOnce

--- a/values.yaml
+++ b/values.yaml
@@ -243,6 +243,8 @@ database:
     ssl: false
     username: georchestra
   primary:  # section of parameters for builtin database
+    persistentVolumeClaimRetentionPolicy:
+      enabled: true
     extraVolumeMounts:
       - name: "00-initsql"
         mountPath: "/docker-entrypoint-initdb.d/00_init.sql"


### PR DESCRIPTION
By default, if you uninstall the helm chart all the automatically created PVC resources are deleted.

This may not be desired at all because that's where all the important data is stored.

This PR proposes to keep all the PVC resources by default and avoid helm deleting them.