### PR TITLE
gateway - removing configuration overrides

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -126,7 +126,7 @@ georchestra:
       enabled: false
       docker_image: georchestra/gateway:latest
       environment:
-        JAVA_TOOL_OPTIONS: "-Dgeorchestra.datadir=/etc/georchestra -Dspring.config.location=${georchestra.datadir}/gateway/application.yaml -Dspring.profiles.active=docker"
+        JAVA_TOOL_OPTIONS: "-Dgeorchestra.datadir=/etc/georchestra"
       extra_environment: []
   datadir:
     volume:


### PR DESCRIPTION
We don't want to fully override the gateway configuration with the one nested in the datadir. These options are redundant with the configuration already provided in the in-app's application.yaml, see here:

https://github.com/georchestra/georchestra-gateway/blob/main/gateway/src/main/resources/application.yml#L19-L21

Also removing the docker profile activation, as I can't find any reference to it either in the default config,  nor in the suggested georchestra/datadir.
