### PR TITLE
remove all prepare emptydir workarounds

### DIFF
--- a/templates/cas/cas-deployment.yaml
+++ b/templates/cas/cas-deployment.yaml
@@ -27,27 +27,6 @@ spec:
         {{- end }}
       initContainers:
       {{- include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
-      - name: prepare-cas-webapp
-        image: {{ $webapp.docker_image }}
-        imagePullPolicy: Always
-        volumeMounts:
-        - mountPath: /etc/georchestra
-          name: georchestra-datadir
-        - mountPath: /cas-webapp
-          name: cas-webapp
-        command:
-        - /bin/sh
-        - -c
-        - cp -r /var/lib/jetty/webapps/cas/* /cas-webapp ;
-          if [ -d /etc/georchestra/cas/themes ] ; then
-            cp -rvf /etc/georchestra/cas/themes /cas-webapp/WEB-INF/classes/static/ ;
-          fi ;
-          if [ -d /etc/georchestra/cas/templates ] ; then
-            cp -rvf /etc/georchestra/cas/templates /cas-webapp/WEB-INF/classes/ ;
-          fi ;
-          if [ -d /etc/georchestra/cas/classes_override ] ; then
-            cp -rvf /etc/georchestra/cas/classes_override/* /cas-webapp/WEB-INF/classes/ ;
-          fi
       containers:
       - name: georchestra-cas
         image: {{ $webapp.docker_image }}
@@ -62,8 +41,6 @@ spec:
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir
-          - mountPath: /var/lib/jetty/webapps/cas
-            name: cas-webapp
         ports:
         - containerPort: 8080
           name: http-proxy
@@ -79,8 +56,6 @@ spec:
           periodSeconds: 60
       volumes:
       - name: georchestra-datadir
-        emptyDir: {}
-      - name: cas-webapp
         emptyDir: {}
       {{- if .Values.georchestra.datadir.git.ssh_secret }}
       - name: ssh-secret

--- a/templates/geonetwork/geonetwork-deployment.yaml
+++ b/templates/geonetwork/geonetwork-deployment.yaml
@@ -38,21 +38,6 @@ spec:
         fsGroup: 999
       initContainers:
       {{ include "georchestra.bootstrap_georchestra_datadir" $ | nindent 6 }}
-      - name: prepare-geonetwork-webapp
-        image: {{ $webapp.docker_image }}
-        imagePullPolicy: Always
-        command:
-        - /bin/sh
-        - -c
-        - cp -r /var/lib/jetty/webapps/geonetwork/* /mnt/geonetwork_webapp ;
-          if [ -f /mnt/georchestra_datadir/geonetwork/web.xml ] ; then
-            cp /mnt/georchestra_datadir/geonetwork/web.xml /mnt/geonetwork_webapp/WEB-INF/web.xml ;
-          fi ;
-        volumeMounts:
-          - name: georchestra-datadir
-            mountPath: /mnt/georchestra_datadir
-          - name: geonetwork-webapp
-            mountPath: /mnt/geonetwork_webapp
       - name: fix-permissions-pvc
         image: busybox:latest
         command: ["sh", "-c", "chown -R 999:999 /mnt/geonetwork_datadir"]
@@ -84,8 +69,6 @@ spec:
             name: georchestra-datadir
           - mountPath: /mnt/geonetwork_datadir
             name: geonetwork-datadir
-          - mountPath: /var/lib/jetty/webapps/geonetwork
-            name: geonetwork-webapp
         {{- if $webapp.extra_volumeMounts }}
           {{ $webapp.extra_volumeMounts | toYaml | nindent 10 }}
         {{- end }}
@@ -127,8 +110,6 @@ spec:
       {{- end }}
       volumes:
       - name: georchestra-datadir
-        emptyDir: {}
-      - name: geonetwork-webapp
         emptyDir: {}
       - name: geonetwork-datadir
         persistentVolumeClaim:

--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -43,24 +43,6 @@ spec:
         fsGroup: 999
       initContainers:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
-      - name: prepare-geoserver-webapp
-        image: {{ $webapp.docker_image }}
-        imagePullPolicy: Always
-        command:
-        - /bin/sh
-        - -c
-        - cp -r /var/lib/jetty/webapps/geoserver/* /mnt/geoserver_webapp ;
-          if [ -f /mnt/georchestra_datadir/geoserver/jetty-env.xml ] ; then
-            cp /mnt/georchestra_datadir/geoserver/jetty-env.xml /mnt/geoserver_webapp/WEB-INF/jetty-env.xml ;
-          fi ;
-          if [ -f /mnt/georchestra_datadir/geoserver/web.xml ] ; then
-            cp /mnt/georchestra_datadir/geoserver/web.xml /mnt/geoserver_webapp/WEB-INF/web.xml ;
-          fi ;
-        volumeMounts:
-          - name: georchestra-datadir
-            mountPath: /mnt/georchestra_datadir
-          - name: geoserver-webapp
-            mountPath: /mnt/geoserver_webapp
       - name: fix-permissions-pvc
         image: busybox:latest
         command: ["sh", "-c", "chown -R 999:999 /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles"]
@@ -207,8 +189,6 @@ spec:
             name: geoserver-geodata
           - mountPath: /mnt/geoserver_datadir
             name: geoserver-datadir
-          - mountPath: /var/lib/jetty/webapps/geoserver
-            name: geoserver-webapp
           - mountPath: /mnt/geoserver_tiles
             name: geoserver-tiles
           {{- range $webapp.extra_volumes }}
@@ -251,8 +231,6 @@ spec:
       {{- end }}
       volumes:
       - name: georchestra-datadir
-        emptyDir: {}
-      - name: geoserver-webapp
         emptyDir: {}
       - name: geoserver-tiles
         persistentVolumeClaim:

--- a/templates/security-proxy/security-proxy-deployment.yaml
+++ b/templates/security-proxy/security-proxy-deployment.yaml
@@ -50,27 +50,9 @@ spec:
           {{- $webapp.extra_environment | toYaml | nindent 10 }}
           {{- end }}
       {{- end }}
-      - name: prepare-proxy-webapp
-        image: {{ $webapp.docker_image }}
-        imagePullPolicy: Always
-        command:
-          - /bin/sh
-          - -c
-          - cp -r /var/lib/jetty/webapps/ROOT/* /mnt/security_proxy_webapp ;
-            if [ -d /mnt/georchestra_datadir/security-proxy/ressources/ ] ; then
-              cp /mnt/georchestra_datadir/security-proxy/ressources/* /mnt/security_proxy_webapp/ ;
-            fi ;
         volumeMounts:
           - name: georchestra-datadir
             mountPath: /mnt/georchestra_datadir
-          - name: security-proxy-webapp
-            mountPath: /mnt/security_proxy_webapp
-      - name: fix-permissions-pvc
-        image: busybox:latest
-        command: [ "sh", "-c", "chown -R 999:999 /mnt/security_proxy_webapp" ]
-        volumeMounts:
-          - mountPath: /mnt/security_proxy_webapp
-            name: security-proxy-webapp
 
       containers:
       - name: georchestra-sp
@@ -90,8 +72,6 @@ spec:
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir
-          - mountPath: /var/lib/jetty/webapps/ROOT/
-            name: security-proxy-webapp
         livenessProbe:
           httpGet:
             path: /_static/bootstrap_3.0.0/css/bootstrap-theme.min.css
@@ -121,8 +101,6 @@ spec:
       {{- end }}
       volumes:
       - name: georchestra-datadir
-        emptyDir: {}
-      - name: security-proxy-webapp
         emptyDir: {}
       {{- if .Values.georchestra.datadir.git.ssh_secret }}
       - name: ssh-secret


### PR DESCRIPTION
Since https://github.com/georchestra/georchestra/issues/4030#issuecomment-1845336454 was merged, there is now an official way to deal with small changes in the geOrchestra components.

This commit removes all the "prepare" emptyDir which were used to override files in the container before the startup.

As camptocamp relied on it a lot, for all the clients there will be a need to convert the overriding files logic into a custom script.

Close https://github.com/georchestra/helm-georchestra/issues/77