### PR TITLE
Remove usage of emptyDir for datafeeder upload

### DIFF
--- a/templates/datafeeder/datafeeder-deployment.yaml
+++ b/templates/datafeeder/datafeeder-deployment.yaml
@@ -106,8 +106,6 @@ spec:
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir
-          - mountPath: /tmp/datafeeder
-            name: datafeeder-uploads
         livenessProbe:
           tcpSocket:
             port: http-proxy
@@ -115,8 +113,6 @@ spec:
           initialDelaySeconds: 20
       volumes:
       - name: georchestra-datadir
-        emptyDir: {}
-      - name: datafeeder-uploads
         emptyDir: {}
       {{- if .Values.georchestra.datadir.git.ssh_secret }}
       - name: ssh-secret


### PR DESCRIPTION
Doesn't make sense to use an emptyDir for that because the ephemeral filesystem of the container is already enough.

It's also using precious emptyDir disk space.

In the future, maybe useful to allow this to be configured in order to for example use a PVC so that it doesn't use the local disk space. Not sure if this directory is just for "temporary" files and these files are immediately deleted once the import is done.