### PR TITLE
keep failed or finished job only for 1 day

### DIFF
--- a/templates/geonetwork/housekeeping/clean-harvester-logs.yaml
+++ b/templates/geonetwork/housekeeping/clean-harvester-logs.yaml
@@ -11,6 +11,7 @@ spec:
   schedule: "{{ $webapp.housekeeping.harvester_logs.schedule }}"
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 86400
       template:
         spec:
           containers:


### PR DESCRIPTION
Documented here: https://kubernetes.io/docs/concepts/workloads/controllers/ttlafterfinished/#cleanup-for-finished-jobs

Do not keep the failed or finished job for too long in order to avoid polluting the job history of Kubernetes.