### PR TITLE
add support for other options with PVC

### DIFF
--- a/templates/geonetwork/elasticsearch/es-data-pvc.yaml
+++ b/templates/geonetwork/elasticsearch/es-data-pvc.yaml
@@ -11,9 +11,21 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  - ReadWriteOnce
-  {{- if $webapp_storage.storage_class_name }}
+  {{- if $webapp_storage.accessModes }}
+  {{- range $webapp_storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range .Values.georchestra.storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq "-" $webapp_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $webapp_storage.storage_class_name }}
   storageClassName: {{ $webapp_storage.storage_class_name }}
+  {{- else if (eq "-" .Values.georchestra.storage.storage_class_name) }}
+  storageClassName: ""
   {{- else if .Values.georchestra.storage.storage_class_name }}
   storageClassName: {{ .Values.georchestra.storage.storage_class_name }}
   {{- end }}

--- a/templates/geonetwork/geonetwork-datadir-pvc.yaml
+++ b/templates/geonetwork/geonetwork-datadir-pvc.yaml
@@ -11,9 +11,21 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  - ReadWriteOnce
-  {{- if $webapp_storage.storage_class_name }}
+  {{- if $webapp_storage.accessModes }}
+  {{- range $webapp_storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range .Values.georchestra.storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq "-" $webapp_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $webapp_storage.storage_class_name }}
   storageClassName: {{ $webapp_storage.storage_class_name }}
+  {{- else if (eq "-" .Values.georchestra.storage.storage_class_name) }}
+  storageClassName: ""
   {{- else if .Values.georchestra.storage.storage_class_name }}
   storageClassName: {{ .Values.georchestra.storage.storage_class_name }}
   {{- end }}

--- a/templates/geoserver/geoserver-datadir-pvc.yaml
+++ b/templates/geoserver/geoserver-datadir-pvc.yaml
@@ -11,9 +11,21 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  - ReadWriteOnce
-  {{- if $webapp_storage.storage_class_name }}
+  {{- if $webapp_storage.accessModes }}
+  {{- range $webapp_storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range .Values.georchestra.storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq "-" $webapp_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $webapp_storage.storage_class_name }}
   storageClassName: {{ $webapp_storage.storage_class_name }}
+  {{- else if (eq "-" .Values.georchestra.storage.storage_class_name) }}
+  storageClassName: ""
   {{- else if .Values.georchestra.storage.storage_class_name }}
   storageClassName: {{ .Values.georchestra.storage.storage_class_name }}
   {{- end }}

--- a/templates/geoserver/geoserver-geodata-pvc.yaml
+++ b/templates/geoserver/geoserver-geodata-pvc.yaml
@@ -11,9 +11,21 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  - ReadWriteOnce
-  {{- if $webapp_storage.storage_class_name }}
+  {{- if $webapp_storage.accessModes }}
+  {{- range $webapp_storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range .Values.georchestra.storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq "-" $webapp_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $webapp_storage.storage_class_name }}
   storageClassName: {{ $webapp_storage.storage_class_name }}
+  {{- else if (eq "-" .Values.georchestra.storage.storage_class_name) }}
+  storageClassName: ""
   {{- else if .Values.georchestra.storage.storage_class_name }}
   storageClassName: {{ .Values.georchestra.storage.storage_class_name }}
   {{- end }}

--- a/templates/geoserver/geoserver-tiles-pvc.yaml
+++ b/templates/geoserver/geoserver-tiles-pvc.yaml
@@ -11,9 +11,21 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  - ReadWriteOnce
-  {{- if $webapp_storage.storage_class_name }}
+  {{- if $webapp_storage.accessModes }}
+  {{- range $webapp_storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range .Values.georchestra.storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq "-" $webapp_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $webapp_storage.storage_class_name }}
   storageClassName: {{ $webapp_storage.storage_class_name }}
+  {{- else if (eq "-" .Values.georchestra.storage.storage_class_name) }}
+  storageClassName: ""
   {{- else if .Values.georchestra.storage.storage_class_name }}
   storageClassName: {{ .Values.georchestra.storage.storage_class_name }}
   {{- end }}

--- a/templates/ldap/openldap-pvc-config.yaml
+++ b/templates/ldap/openldap-pvc-config.yaml
@@ -11,9 +11,21 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  - ReadWriteOnce
-  {{- if $webapp_storage.storage_class_name }}
+  {{- if $webapp_storage.accessModes }}
+  {{- range $webapp_storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range .Values.georchestra.storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq "-" $webapp_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $webapp_storage.storage_class_name }}
   storageClassName: {{ $webapp_storage.storage_class_name }}
+  {{- else if (eq "-" .Values.georchestra.storage.storage_class_name) }}
+  storageClassName: ""
   {{- else if .Values.georchestra.storage.storage_class_name }}
   storageClassName: {{ .Values.georchestra.storage.storage_class_name }}
   {{- end }}

--- a/templates/ldap/openldap-pvc-data.yaml
+++ b/templates/ldap/openldap-pvc-data.yaml
@@ -11,9 +11,21 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  - ReadWriteOnce
-  {{- if $webapp_storage.storage_class_name }}
+  {{- if $webapp_storage.accessModes }}
+  {{- range $webapp_storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range .Values.georchestra.storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq "-" $webapp_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $webapp_storage.storage_class_name }}
   storageClassName: {{ $webapp_storage.storage_class_name }}
+  {{- else if (eq "-" .Values.georchestra.storage.storage_class_name) }}
+  storageClassName: ""
   {{- else if .Values.georchestra.storage.storage_class_name }}
   storageClassName: {{ .Values.georchestra.storage.storage_class_name }}
   {{- end }}

--- a/templates/mapstore/mapstore-pvc.yaml
+++ b/templates/mapstore/mapstore-pvc.yaml
@@ -11,9 +11,21 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  - ReadWriteOnce
-  {{- if $webapp_storage.storage_class_name }}
+  {{- if $webapp_storage.accessModes }}
+  {{- range $webapp_storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range .Values.georchestra.storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq "-" $webapp_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $webapp_storage.storage_class_name }}
   storageClassName: {{ $webapp_storage.storage_class_name }}
+  {{- else if (eq "-" .Values.georchestra.storage.storage_class_name) }}
+  storageClassName: ""
   {{- else if .Values.georchestra.storage.storage_class_name }}
   storageClassName: {{ .Values.georchestra.storage.storage_class_name }}
   {{- end }}

--- a/templates/rabbitmq/rabbitmq-pvc.yaml
+++ b/templates/rabbitmq/rabbitmq-pvc.yaml
@@ -1,4 +1,5 @@
 {{- $rabbitmq := .Values.rabbitmq -}}
+{{- $rabbitmq_storage := .Values.georchestra.storage.mapstore_datadir -}}
 {{- if and $rabbitmq.enabled $rabbitmq.storage -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -9,14 +10,20 @@ metadata:
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-rabbitmq
 spec:
   accessModes:
-  - ReadWriteOnce
-  {{- if $rabbitmq.storage.storage_class_name }}
-  storageClassName: {{ $rabbitmq.storage.storage_class_name }}
+  {{- if $rabbitmq_storage.accessModes }}
+  {{- range $rabbitmq_storage.accessModes }}
+  - {{ . | quote }}
   {{- end }}
-  {{- if $rabbitmq.storage.pv_name }}
-  volumeName: {{ $rabbitmq.storage.pv_name }}
+  {{- end }}
+  {{- if (eq "-" $rabbitmq_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $rabbitmq_storage.storage_class_name }}
+  storageClassName: {{ $rabbitmq_storage.storage_class_name }}
+  {{- end }}
+  {{- if $rabbitmq_storage.pv_name }}
+  volumeName: {{ $rabbitmq_storage.pv_name }}
   {{- end }}
   resources:
     requests:
-      storage: {{ $rabbitmq.storage.size }}
+      storage: {{ $rabbitmq_storage.size }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -186,7 +186,9 @@ georchestra:
     geoserver_geodata:
       # pv_name: geoserver_geodata
       # works for other storage items
-      # storage_class_name: default
+      # storage_class_name: default or "-" for empty storageClassName
+      # accessModes:
+      # - ReadWriteOnce
       size: 2Gi
     mapstore_datadir:
       # pv_name: mapstore_datadir
@@ -202,7 +204,9 @@ georchestra:
       size: 2Gi
     # We also might need to specify a custom storageClass
     # Leave it commented if not needed
-    # storage_class_name: default
+    # storage_class_name: default or "-" for empty storageClassName
+    accessModes:
+    - ReadWriteOnce
   smtp_smarthost:
     enabled: true
     # mailname: georchestra-127-0-1-1.traefik.me


### PR DESCRIPTION
- Allow the ability to specify an empty storageClassName which disable automatic provisioning of the PVC. See https://github.com/helm/helm/issues/2600
- Allow the ability to configure accessModes. For example for PV hosted on NFS. [Example](https://github.com/kubernetes/examples/blob/master/staging/volumes/nfs/nfs-pvc.yaml)

I did try to use helm helper for that now that there is a lot of redundancy but failed to because $webapp and $webapp_storage are dynamic. May try in another PR.