### PR TITLE
add ability to configure service annotations

### DIFF
--- a/templates/analytics/analytics-svc.yaml
+++ b/templates/analytics/analytics-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-analytics
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/cas/cas-svc.yaml
+++ b/templates/cas/cas-svc.yaml
@@ -7,7 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-cas
-
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/console/console-svc.yaml
+++ b/templates/console/console-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-console
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/datafeeder/datafeeder-svc.yaml
+++ b/templates/datafeeder/datafeeder-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-datafeeder
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/datafeeder/import-svc.yaml
+++ b/templates/datafeeder/import-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-datafeeder-import
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 80

--- a/templates/extractorapp/extractorapp-svc.yaml
+++ b/templates/extractorapp/extractorapp-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-extractorapp
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/gateway/gateway-svc.yaml
+++ b/templates/gateway/gateway-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gateway
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/geonetwork/elasticsearch/es-svc.yaml
+++ b/templates/geonetwork/elasticsearch/es-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gn4-elasticsearch
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 9200

--- a/templates/geonetwork/geonetwork-svc.yaml
+++ b/templates/geonetwork/geonetwork-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geonetwork
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/geonetwork/kibana/kibana-svc.yaml
+++ b/templates/geonetwork/kibana/kibana-svc.yaml
@@ -1,3 +1,4 @@
+{{- $webapp := .Values.georchestra.webapps.geonetwork.kibana -}}
 {{- if .Values.georchestra.webapps.geonetwork.enabled -}}
 apiVersion: v1
 kind: Service
@@ -6,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gn4-kibana
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 5601

--- a/templates/geonetwork/ogc-api-records/ogc-api-records-svc.yaml
+++ b/templates/geonetwork/ogc-api-records/ogc-api-records-svc.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.georchestra.webapps.geonetwork.enabled .Values.georchestra.webapps.geonetwork.ogc_api_records.enabled -}}
+{{- $webapp := .Values.georchestra.webapps.geonetwork.ogc_api_records -}}
+{{- if and .Values.georchestra.webapps.geonetwork.enabled $webapp.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gn4-ogc-api-records
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/geoserver/geoserver-svc.yaml
+++ b/templates/geoserver/geoserver-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geoserver
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/header/header-svc.yaml
+++ b/templates/header/header-svc.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.georchestra.webapps.header.enabled -}}
+{{- $webapp := .Values.georchestra.webapps.header -}}
+{{- if $webapp.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -6,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-header
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/ldap/openldap-svc.yaml
+++ b/templates/ldap/openldap-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-ldap
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 389

--- a/templates/mapfishapp/mapfishapp-svc.yaml
+++ b/templates/mapfishapp/mapfishapp-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-mapfishapp
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/mapstore/mapstore-svc.yaml
+++ b/templates/mapstore/mapstore-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-mapstore
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/templates/security-proxy/security-proxy-svc.yaml
+++ b/templates/security-proxy/security-proxy-svc.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-sp
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   ports:
   - port: 8080

--- a/values.yaml
+++ b/values.yaml
@@ -19,12 +19,16 @@ georchestra:
       docker_image: georchestra/analytics:latest
       extra_environment: []
       # registry_secret: default
+      service:
+        annotations: {}
     cas:
       enabled: true
       replicaCount: "1"
       docker_image: georchestra/cas:latest
       extra_environment: []
       # registry_secret: default
+      service:
+        annotations: {}
     console:
       enabled: true
       replicaCount: "1"
@@ -32,6 +36,8 @@ georchestra:
       extra_environment: []
       lifecycle: {}
       # registry_secret: default
+      service:
+        annotations: {}
     datafeeder:
       enabled: true  # won't deploy if datafeeder_frontend is not enable
       replicaCount: "1"
@@ -44,6 +50,8 @@ georchestra:
       # registry_secret: default
       envsubst:
         enabled: true
+      service:
+        annotations: {}
     datafeeder_frontend:
       # Matches datafeeder/import-xxx.yaml templates in the helm chart
       enabled: true  # won't deploy if datafeeder is not enable
@@ -52,12 +60,16 @@ georchestra:
       lifecycle: {}
       extra_environment: []
       # registry_secret: default
+      service:
+        annotations: {}
     extractorapp:
       enabled: false
       replicaCount: "1"
       docker_image: georchestra/extractorapp:latest
       extra_environment: []
       # registry_secret: default
+      service:
+        annotations: {}
     geonetwork:
       enabled: true
       replicaCount: "1"
@@ -80,6 +92,8 @@ georchestra:
         extra_environment: []
         envsubst:
           enabled: true
+        service:
+          annotations: {}
       elasticsearch:
         replicaCount: "1"
         resources:
@@ -88,14 +102,20 @@ georchestra:
           requests:
             memory: 5120Mi
         image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
+        service:
+          annotations: {}
       kibana:
         replicaCount: "1"
         image: docker.elastic.co/kibana/kibana:7.15.1
+        service:
+          annotations: {}
       # automatically clean some logs of geonetwork
       housekeeping:
         harvester_logs:
           enabled: false
           schedule: "0 1 * * *"
+      service:
+        annotations: {}
     geoserver:
       enabled: true
       replicaCount: "1"
@@ -110,18 +130,24 @@ georchestra:
       # variable above.
       extra_volumeMounts: []
       # registry_secret: default
+      service:
+        annotations: {}
     header:
       enabled: true
       replicaCount: "1"
       docker_image: georchestra/header:latest
       extra_environment: []
       # registry_secret: default
+      service:
+        annotations: {}
     mapfishapp:
       enabled: false
       replicaCount: "1"
       docker_image: georchestra/mapfishapp:latest
       extra_environment: []
       # registry_secret: default
+      service:
+        annotations: {}
     mapstore:
       enabled: true
       replicaCount: "1"
@@ -132,6 +158,8 @@ georchestra:
       command: []
       args: []
       lifecycle: {}
+      service:
+        annotations: {}
     openldap:
       enabled: true
       replicaCount: "1"
@@ -146,6 +174,8 @@ georchestra:
       #  - name: my-sidecar
       #    image: nginx:latest
       # registry_secret: default
+      service:
+        annotations: {}
     proxy:
       enabled: true
       replicaCount: "1"
@@ -155,6 +185,8 @@ georchestra:
       # registry_secret: default
       envsubst:
         enabled: true
+      service:
+        annotations: {}
     gateway:
       enabled: false
       replicaCount: "1"
@@ -162,6 +194,8 @@ georchestra:
       environment:
         JAVA_TOOL_OPTIONS: "-Dgeorchestra.datadir=/etc/georchestra"
       extra_environment: []
+      service:
+        annotations: {}
   datadir:
     volume:
     - name: georchestra-datadir


### PR DESCRIPTION
This PR adds the ability to configure service annotations.

One such use case is to insert traefik specific annotations for the service, like for these ones: https://doc.traefik.io/traefik/routing/providers/kubernetes-ingress/#on-service