### PR TITLE
Better healthcheck geoserver

### DIFF
--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -202,7 +202,7 @@ spec:
         {{- else }}
         livenessProbe:
           httpGet:
-            path: /geoserver/gwc/service/wmts?SERVICE=WMTS&REQUEST=GetCapabilities
+            path: /geoserver/ows?SERVICE=WMS&LAYERS=geor:public_layer&FORMAT=image/png&VERSION=1.3.0&SLD_VERSION=1.1.0&REQUEST=GetMap&CRS=EPSG:3857&BBOX=-20820223,-20820223,20820223,20820223&WIDTH=10&HEIGHT=10
             port: 8080
           periodSeconds: 10
           timeoutSeconds: 5


### PR DESCRIPTION
This change the healthcheck of geoserver because:
- The healthcheck fail when some external datastores doesn't work.
- This is compute expensive to load this request on large datastores.

Half downside:
- layer geor:public_layer needs to exist