### PR TITLE
Upgrade elasticsearch to latest support version by geonetwork

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -101,7 +101,7 @@ georchestra:
             memory: 5120Mi
           requests:
             memory: 5120Mi
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.15.1
+        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.21
         service:
           annotations: {}
       kibana:


### PR DESCRIPTION
Goes accordingly with the migration notes for geOrchestra 24: https://github.com/georchestra/georchestra/blob/24.0/migrations/24.0/README.md

geonetwork 4.2.X support elasticsearch 7.17.X: https://github.com/docker-library/docs/tree/master/geonetwork