### PR TITLE
Set georchestra gateway by default

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -177,7 +177,7 @@ georchestra:
       service:
         annotations: {}
     proxy:
-      enabled: true
+      enabled: false
       replicaCount: "1"
       docker_image: georchestra/security-proxy:latest
       jetty_monitoring: false
@@ -188,7 +188,7 @@ georchestra:
       service:
         annotations: {}
     gateway:
-      enabled: false
+      enabled: true
       replicaCount: "1"
       docker_image: georchestra/gateway:latest
       environment:


### PR DESCRIPTION
In the docker compose we set to enable gateway by default but with the ability to still use security-proxy: https://github.com/georchestra/georchestra/issues/3881#issuecomment-2151763697

So in Kubernetes we will do the same.