### PR TITLE
geoserver strategy rolling update

### DIFF
--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -14,8 +14,6 @@ metadata:
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geoserver
 spec:
   replicas: {{ $webapp.replicaCount }}
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       {{- include "georchestra.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
This switches to strategy rolling update for geoserver in order to keep the traffic flowing to the old geoserver until the new one is healthy.

We think this will not cause any potential issue because we can see in many helm charts that nobody is using strategy recreate:
- https://github.com/kumulustech/geoserver-helm/blob/main/charts/geoserver/templates/deployment.yaml
- https://github.com/kartoza/charts/blob/develop/charts/geoserver/v0.3.3/templates/deployment.yaml

Advantage: no downtime when deploying new changes to geoserver