### PR TITLE
change healthcheck probes for header

### DIFF
--- a/templates/header/header-deployment.yaml
+++ b/templates/header/header-deployment.yaml
@@ -48,17 +48,15 @@ spec:
             name: georchestra-datadir
         ports:
         - containerPort: 8080
-          name: http-proxy
+          name: http
         livenessProbe:
           httpGet:
-            path: /header/img/logo.png
-            port: 8080
-          periodSeconds: 10
-        startupProbe:
-          tcpSocket:
-            port: 8080
-          failureThreshold: 5
-          periodSeconds: 30
+            path: /header/
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /header/
+            port: http
       volumes:
       - name: georchestra-datadir
         emptyDir: {}

--- a/templates/header/header-svc.yaml
+++ b/templates/header/header-svc.yaml
@@ -15,7 +15,7 @@ spec:
   ports:
   - port: 8080
     protocol: TCP
-    targetPort: 8080
+    targetPort: http
   selector:
     org.georchestra.service/name: {{ include "georchestra.fullname" . }}-header
 {{- end }}


### PR DESCRIPTION
checking a logo.png is unnecessary because the header may not have this file (in case of customized header docker image).

checking /header/ is much better because you check all the app capability