### PR TITLE
allow custom liveness startup probe for mapstore and geoserver

### DIFF
--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -195,8 +195,9 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
-        {{- if $webapp.custom_liveness_probe }}
-        {{ $webapp.custom_liveness_probe | toYaml | nindent 8 }}
+        {{- if $webapp.livenessProbe }}
+        livenessProbe:
+          {{ $webapp.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
         livenessProbe:
           httpGet:
@@ -205,11 +206,16 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         {{- end }}
+        {{- if $webapp.startupProbe }}
+        startupProbe:
+          {{ $webapp.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           tcpSocket:
             port: 8080
           failureThreshold: 5
           periodSeconds: 40
+        {{- else }}
       {{- if $webapp.jetty_monitoring }}
       - name: jmx-collectd
         image: camptocamp/jmx-collectd:bullseye

--- a/templates/mapstore/mapstore-deployment.yaml
+++ b/templates/mapstore/mapstore-deployment.yaml
@@ -63,17 +63,27 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if $webapp.livenessProbe }}
+        livenessProbe:
+          {{ $webapp.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /mapstore/configs/config.json
             port: 8080
           periodSeconds: 10
+        {{- end }}
+        {{- if $webapp.startupProbe }}
+        startupProbe:
+          {{ $webapp.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           httpGet:
             path: /mapstore/configs/config.json
             port: 8080
           failureThreshold: 5
           periodSeconds: 15
+        {{- end }}
       volumes:
       - name: georchestra-datadir
         emptyDir: {}

--- a/values.yaml
+++ b/values.yaml
@@ -119,6 +119,8 @@ georchestra:
     geoserver:
       enabled: true
       replicaCount: "1"
+      livenessProbe: []
+      startupProbe: []
       docker_image: georchestra/geoserver:latest
       jetty_monitoring: false
       extra_environment: []


### PR DESCRIPTION
I have only added the parameters on the geoserver section because I plan to expose the parameters in another file like explained in https://github.com/georchestra/helm-georchestra/issues/100

I'll expose the custom livenessProbe and startupProbe for all the other components later.