### PR TITLE
add geowebcache component to the helm chart

### DIFF
--- a/templates/geowebcache/geowebcache-deployment.yaml
+++ b/templates/geowebcache/geowebcache-deployment.yaml
@@ -1,0 +1,89 @@
+{{- $webapp := .Values.georchestra.webapps.geowebcache -}}
+{{- if $webapp.enabled -}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "georchestra.fullname" . }}-geowebcache
+  labels:
+    {{- include "georchestra.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geowebcache
+spec:
+  replicas: {{ $webapp.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "georchestra.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geowebcache
+  template:
+    metadata:
+      labels:
+        {{- include "georchestra.selectorLabels" . | nindent 8 }}
+        org.georchestra.service/name: {{ include "georchestra.fullname" . }}-geowebcache
+        app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geowebcache
+    spec:
+      nodeSelector:
+        "kubernetes.io/os": linux
+        {{- with .Values.georchestra.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      securityContext:
+        fsGroup: 999
+      initContainers:
+      {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
+      containers:
+      - name: georchestra-geowebcache
+        image: {{ $webapp.docker_image }}
+        imagePullPolicy: Always
+        env:
+          {{- include "georchestra.database-georchestra-envs" . | nindent 10 }}
+          {{- if $webapp.extra_environment }}
+          {{- $webapp.extra_environment | toYaml | nindent 10 }}
+          {{- end }}
+        volumeMounts:
+          - mountPath: /etc/georchestra
+            name: georchestra-datadir
+          - mountPath: /mnt/geowebcache_tiles
+            name: geowebcache-tiles
+          {{- if $webapp.extra_volumeMounts }}
+            {{ $webapp.extra_volumeMounts | toYaml | nindent 10 }}
+          {{- end }}
+        ports:
+        - containerPort: 80
+          name: http
+        {{- if $webapp.livenessProbe }}
+        {{ $webapp.livenessProbe | toYaml | nindent 8 }}
+        {{- else }}
+        livenessProbe:
+          httpGet:
+            path: /geowebcache/
+            port: http
+        {{- end }}
+        startupProbe:
+          failureThreshold: 5
+          httpGet:
+            path: /geowebcache/
+            port: http
+          initialDelaySeconds: 45
+          periodSeconds: 15
+          successThreshold: 1
+          timeoutSeconds: 1
+      volumes:
+      - name: georchestra-datadir
+        emptyDir: {}
+      - name: geowebcache-tiles
+        persistentVolumeClaim:
+          claimName: {{ include "georchestra.fullname" . }}-geowebcache-tiles
+      {{- if .Values.georchestra.datadir.git.ssh_secret }}
+      - name: ssh-secret
+        secret:
+          secretName: {{ .Values.georchestra.datadir.git.ssh_secret }}
+          defaultMode: 0400
+      {{- end }}
+      {{- if $webapp.extra_volumes }}
+        {{ $webapp.extra_volumes | toYaml | nindent 6 }}
+      {{- end }}
+      {{- if $webapp.registry_secret }}
+      imagePullSecrets:
+      - name: {{ $webapp.registry_secret }}
+      {{- end }}
+{{- end }}

--- a/templates/geowebcache/geowebcache-svc.yaml
+++ b/templates/geowebcache/geowebcache-svc.yaml
@@ -1,0 +1,21 @@
+{{- $webapp := .Values.georchestra.webapps.geowebcache -}}
+{{- if $webapp.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "georchestra.fullname" . }}-geowebcache-svc
+  labels:
+    {{- include "georchestra.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geowebcache
+  {{- with $webapp.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  ports:
+  - port: 80
+    protocol: TCP
+    targetPort: http
+  selector:
+    org.georchestra.service/name: {{ include "georchestra.fullname" . }}-geowebcache
+{{- end }}

--- a/templates/geowebcache/geowebcache-tiles-pvc.yaml
+++ b/templates/geowebcache/geowebcache-tiles-pvc.yaml
@@ -1,0 +1,38 @@
+{{- $webapp := .Values.georchestra.webapps.geowebcache -}}
+{{- $webapp_storage := .Values.georchestra.storage.geowebcache_tiles -}}
+{{- if and $webapp.enabled .Values.georchestra.storage.geowebcache_tiles -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "georchestra.fullname" . }}-geowebcache-tiles
+  labels:
+    {{- include "georchestra.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geowebcache
+    helm.sh/resource-policy: "keep"
+spec:
+  accessModes:
+  {{- if $webapp_storage.accessModes }}
+  {{- range $webapp_storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- else }}
+  {{- range .Values.georchestra.storage.accessModes }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  {{- if (eq "-" $webapp_storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if $webapp_storage.storage_class_name }}
+  storageClassName: {{ $webapp_storage.storage_class_name }}
+  {{- else if (eq "-" .Values.georchestra.storage.storage_class_name) }}
+  storageClassName: ""
+  {{- else if .Values.georchestra.storage.storage_class_name }}
+  storageClassName: {{ .Values.georchestra.storage.storage_class_name }}
+  {{- end }}
+  {{- if $webapp_storage.pv_name }}
+  volumeName: {{ $webapp_storage.pv_name }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ $webapp_storage.size }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -132,6 +132,13 @@ georchestra:
       # registry_secret: default
       service:
         annotations: {}
+    geowebcache:
+      enabled: false
+      replicaCount: "1"
+      docker_image: georchestra/geowebcache:latest
+      extra_environment: []
+      service:
+        annotations: {}
     header:
       enabled: true
       replicaCount: "1"
@@ -236,6 +243,9 @@ georchestra:
     geoserver_tiles:
       # pv_name: geoserver_tiles
       size: 2Gi
+    geowebcache_tiles:
+      # pv_name: geowebcache_tiles
+      size: 5Gi
     # We also might need to specify a custom storageClass
     # Leave it commented if not needed
     # storage_class_name: default or "-" for empty storageClassName


### PR DESCRIPTION
Geowebcache is a component not really used by a lot of people, but it's actually officially supported in geOrchestra:
- https://github.com/georchestra/georchestra/tree/master/geowebcache-webapp
- https://github.com/georchestra/docker/blob/master/docker-compose.gwc.yml

This PR adds the ability to configure geowebcache standalone.

For the moment, it is a bit tricky to make it work because you have to pass the env `JAVA_OPTIONS: -DGEOWEBCACHE_CONFIG_DIR=/etc/georchestra/geowebcache`. But there will be soon an official way to support geowebcache.xml from the geOrchestra datadir instead of a separate geowebcache datadir.