### PR TITLE
Disable analytics + fix ingress + update ogc_api_records + fix database

### DIFF
--- a/templates/ingress/ingress.yaml
+++ b/templates/ingress/ingress.yaml
@@ -47,11 +47,19 @@ spec:
             backend:
               {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
+                {{- if $.Values.georchestra.webapps.gateway.enabled }}
+                name: {{ include "georchestra.fullname" $ }}-gateway-svc
+                {{- else }}
                 name: {{ include "georchestra.fullname" $ }}-sp-svc
+                {{- end }}
                 port:
                   number: 8080
               {{- else }}
+              {{- if $.Values.georchestra.webapps.gateway.enabled }}
+              serviceName: {{ include "georchestra.fullname" $ }}-gateway-svc
+              {{- else }}
               serviceName: {{ include "georchestra.fullname" $ }}-sp-svc
+              {{- end }}
               servicePort: 8080
               {{- end }}
           {{- if $.Values.georchestra.webapps.cas.enabled }}

--- a/values.yaml
+++ b/values.yaml
@@ -14,7 +14,7 @@ georchestra:
     # For all the apps, setting a replica count of more than 1 is not supported
     # by the helm chart (cardinality 0..1).
     analytics:
-      enabled: true
+      enabled: false
       replicaCount: "1"
       docker_image: georchestra/analytics:latest
       extra_environment: []
@@ -88,7 +88,7 @@ georchestra:
       ogc_api_records:
         enabled: true
         replicaCount: "1"
-        image: georchestra/gn-cloud-ogc-api-records-service:2021-12-16
+        image: georchestra/gn-cloud-ogc-api-records-service:4.2.8
         extra_environment: []
         envsubst:
           enabled: true
@@ -327,6 +327,10 @@ database:
     ssl: false
     username: georchestra
   primary:  # section of parameters for builtin database
+    startupProbe:
+      enabled: true
+    containerSecurityContext:
+      readOnlyRootFilesystem: false
     persistentVolumeClaimRetentionPolicy:
       enabled: true
     extraVolumeMounts:


### PR DESCRIPTION
- Disable (not remove!) georchestra analytics by default because this component does not work anymore since security proxy is disabled by default.
- Update gn-cloud-ogc-api-records-service to work with latest geonetwork version.
- Default ingress will set gateway by default if you have let gateway by default but will set to SP if you have gateway disabled.
- Fix default postgresql database fresh startup (this should fix the github action checks). Related to recent update of bitnami helm chart for postgresql.