### PR TITLE
add envsubst capability in geowebcache

### DIFF
--- a/templates/geowebcache/geowebcache-deployment.yaml
+++ b/templates/geowebcache/geowebcache-deployment.yaml
@@ -32,6 +32,23 @@ spec:
         fsGroup: 999
       initContainers:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
+      {{- if $webapp.envsubst.enabled }}
+      - name: envsubst
+        image: georchestra/k8s-initcontainer-envsubst
+        volumeMounts:
+        - mountPath: /etc/georchestra
+          name: georchestra-datadir
+        env:
+          - name: DEBUG
+            value: "yes"
+          - name: SUBST_FILES
+            value: "/etc/georchestra/geowebcache/datadir/*"
+          {{- include "georchestra.common-envs" . | nindent 10 }}
+          {{- if $webapp.extra_environment }}
+          {{- $webapp.extra_environment | toYaml | nindent 10 }}
+          {{- end }}
+      {{- end }}
+
       containers:
       - name: georchestra-geowebcache
         image: {{ $webapp.docker_image }}

--- a/values.yaml
+++ b/values.yaml
@@ -135,6 +135,8 @@ georchestra:
     geowebcache:
       enabled: false
       replicaCount: "1"
+      envsubst:
+        enabled: true
       docker_image: georchestra/geowebcache:latest
       extra_environment: []
       service:


### PR DESCRIPTION
geowebcache does not yet support the ability to use environment variables in its .xml config. @pmauduit is working on a solution upstream for geOrchestra

Meanwhile, as it is important to hide secrets from the git repository, envsubst will be used for that.