### PR TITLE
add condition to not create secret if database not buildin

### DIFF
--- a/templates/database/database-georchestra-secret.yaml
+++ b/templates/database/database-georchestra-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.database.builtin -}}
 {{- $database := .Values.database -}}
 {{- if not $database.auth.existingSecret -}}
 apiVersion: v1
@@ -17,4 +18,5 @@ data:
   password: {{ $database.auth.password | b64enc | quote }}
   port: {{ $database.auth.port | b64enc | quote }}
   user: {{ $database.auth.username | b64enc | quote }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
to correct the error : 
` Error: template: georchestra/templates/database/database-georchestra-secret.yaml:15:33: executing "georchestra/templates/database/database-georchestra-secret.yaml" at <b64enc>: invalid value; expected string
  Use --debug flag to render out invalid YAML`