### PR TITLE
Remove second condition about georchestra database secret

### DIFF
--- a/templates/database/database-georchestra-secret.yaml
+++ b/templates/database/database-georchestra-secret.yaml
@@ -1,4 +1,3 @@
-{{- if and (.Values.database.geodata) (not .Values.database.geodata.auth.existingSecret ) }}
 {{- $database := .Values.database -}}
 {{- if not $database.auth.existingSecret -}}
 apiVersion: v1
@@ -18,5 +17,4 @@ data:
   password: {{ $database.auth.password | b64enc | quote }}
   port: {{ $database.auth.port | b64enc | quote }}
   user: {{ $database.auth.username | b64enc | quote }}
-{{- end }}
 {{- end }}


### PR DESCRIPTION
Remove the code introduced in:
- https://github.com/georchestra/helm-georchestra/commit/dce999a59bd695f17b279cfce2363ce61200097f
- https://github.com/georchestra/helm-georchestra/commit/6170e5d32ce44812145fddadc585a80769d48517

@jeanmi151 I tried the values.yaml in the rennes public project and I couldn't reproduce the error message in https://github.com/georchestra/helm-georchestra/pull/111#issue-2504665270

Since we can't find the real root cause, I'll assume that it was a misunderstanding about how the secrets are created by the helm chart at the time of the code was changed.

This secret creation logic has worked fine for many of Camptocamp clients (biotope, haute loire and so on) so I don't see why it wouldn't with rennes public.