### PR TITLE
add required values for database secrets

### DIFF
--- a/templates/database/database-datafeeder-secret.yaml
+++ b/templates/database/database-datafeeder-secret.yaml
@@ -8,9 +8,9 @@ metadata:
     {{- include "georchestra.labels" . | nindent 4 }}
 type: Opaque
 data:
-  dbname: {{ $database.auth.database | b64enc | quote }}
-  host: {{ $database.auth.host | b64enc | quote }}
-  password: {{ $database.auth.password | b64enc | quote }}
-  port: {{ $database.auth.port | b64enc | quote }}
-  user: {{ $database.auth.username | b64enc | quote }}
+  dbname: {{ required ".Values.datafeeder.auth.dbname is required." $database.auth.database | b64enc | quote }}
+  host: {{ required ".Values.datafeeder.auth.host is required." $database.auth.host | b64enc | quote }}
+  password: {{ required ".Values.datafeeder.auth.password is required." $database.auth.password | b64enc | quote }}
+  port: {{ required ".Values.datafeeder.auth.port is required." $database.auth.port | b64enc | quote }}
+  user: {{ required ".Values.datafeeder.auth.username is required." $database.auth.username | b64enc | quote }}
 {{- end }}

--- a/templates/database/database-geodata-secret.yaml
+++ b/templates/database/database-geodata-secret.yaml
@@ -8,9 +8,9 @@ metadata:
     {{- include "georchestra.labels" . | nindent 4 }}
 type: Opaque
 data:
-  dbname: {{ $database.auth.database | b64enc | quote }}
-  host: {{ $database.auth.host | b64enc | quote }}
-  password: {{ $database.auth.password | b64enc | quote }}
-  port: {{ $database.auth.port | b64enc | quote }}
-  user: {{ $database.auth.username | b64enc | quote }}
+  dbname: {{ required ".Values.geodata.auth.dbname is required." $database.auth.database | b64enc | quote }}
+  host: {{ required ".Values.geodata.auth.host is required." $database.auth.host | b64enc | quote }}
+  password: {{ required ".Values.geodata.auth.password is required." $database.auth.password | b64enc | quote }}
+  port: {{ required ".Values.geodata.auth.port is required." $database.auth.port | b64enc | quote }}
+  user: {{ required ".Values.geodata.auth.username is required." $database.auth.username | b64enc | quote }}
 {{- end }}

--- a/templates/database/database-georchestra-secret.yaml
+++ b/templates/database/database-georchestra-secret.yaml
@@ -1,4 +1,3 @@
-{{- if and (.Values.database.geodata) (not .Values.database.geodata.auth.existingSecret ) }}
 {{- $database := .Values.database -}}
 {{- if not $database.auth.existingSecret -}}
 apiVersion: v1
@@ -9,14 +8,13 @@ metadata:
     {{- include "georchestra.labels" . | nindent 4 }}
 type: Opaque
 data:
-  dbname: {{ $database.auth.database | b64enc | quote }}
+  dbname: {{ required ".Values.database.auth.dbname is required." $database.auth.database | b64enc | quote }}
   {{- if $database.builtin }}
   host: {{ printf "%s-database" .Release.Name | b64enc | quote  }}
   {{- else }}
-  host: {{ $database.auth.host | b64enc | quote }}
+  host: {{ required ".Values.database.auth.host is required." $database.auth.host | b64enc | quote }}
   {{- end }}
-  password: {{ $database.auth.password | b64enc | quote }}
-  port: {{ $database.auth.port | b64enc | quote }}
-  user: {{ $database.auth.username | b64enc | quote }}
-{{- end }}
+  password: {{ required ".Values.database.auth.password is required." $database.auth.password | b64enc | quote |  }}
+  port: {{ required ".Values.database.auth.port is required." $database.auth.port | b64enc | quote }}
+  user: {{ required ".Values.database.auth.username is required." $database.auth.username | b64enc | quote }}
 {{- end }}


### PR DESCRIPTION
This adds validation for the required values for the database secrets. That was the issue that appeared in https://github.com/georchestra/helm-georchestra/pull/111, @jeanmi151 was not providing the `host` parameter when database builtin was false.

If you do not provide all the database values, the helm chart will throw you an understandable message.

```
Error: execution error at (georchestra/templates/database/database-georchestra-secret.yaml:15:11): .Values.database.auth.host is required.

Use --debug flag to render out invalid YAML
```

I have also removed the condition in which it doesn't create the georchestra database secret. Because this would allow anybody to have no secrets and not understand why the helm chart doesn't work.

Since the helm chart rely on this required georchestra database secret in order to function. All the deployments use it:
- https://github.com/georchestra/helm-georchestra/blob/main/templates/_helpers-database.tpl#L6

If you try to not have any secret at all, no program will work.

Related to https://github.com/georchestra/helm-georchestra/issues/13