### PR TITLE
monitoring - upgrade jmx-collectd to bookworm

### DIFF
--- a/templates/geonetwork/geonetwork-deployment.yaml
+++ b/templates/geonetwork/geonetwork-deployment.yaml
@@ -78,7 +78,7 @@ spec:
           periodSeconds: 50
       {{- if $webapp.jetty_monitoring }}
       - name: jmx-collectd
-        image: camptocamp/jmx-collectd:bullseye
+        image: camptocamp/jmx-collectd:bookworm
         volumeMounts:
         - mountPath: /collectd-template
           name: georchestra-monitoring-cm

--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -212,7 +212,7 @@ spec:
           periodSeconds: 40
       {{- if $webapp.jetty_monitoring }}
       - name: jmx-collectd
-        image: camptocamp/jmx-collectd:bullseye
+        image: camptocamp/jmx-collectd:bookworm
         volumeMounts:
         - mountPath: /collectd-template
           name: georchestra-monitoring-cm

--- a/templates/security-proxy/security-proxy-deployment.yaml
+++ b/templates/security-proxy/security-proxy-deployment.yaml
@@ -82,7 +82,7 @@ spec:
           periodSeconds: 15
       {{- if $webapp.jetty_monitoring }}
       - name: jmx-collectd
-        image: camptocamp/jmx-collectd:bullseye
+        image: camptocamp/jmx-collectd:bookworm
         volumeMounts:
         - mountPath: /collectd-template
           name: georchestra-monitoring-cm


### PR DESCRIPTION
Tests: the tag has been tested onto a test platform successfully.

Note: the new tag is running as non-privileged user, see https://github.com/georchestra/georchestra/issues/4071#issuecomment-2497526274

----

Source code of the image: https://github.com/camptocamp/docker-jmx-collectd