### PR TITLE
Handle existingClaim for storage conf

### DIFF
--- a/templates/geonetwork/elasticsearch/es-data-pvc.yaml
+++ b/templates/geonetwork/elasticsearch/es-data-pvc.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork.elasticsearch -}}
 {{- $webapp_storage := .Values.georchestra.storage.gn4_es -}}
-{{- if .Values.georchestra.webapps.geonetwork.enabled -}}
+{{- if and .Values.georchestra.webapps.geonetwork.enabled (not $webapp_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/geonetwork/elasticsearch/es-deployment.yaml
+++ b/templates/geonetwork/elasticsearch/es-deployment.yaml
@@ -55,7 +55,7 @@ spec:
       volumes:
       - name: gn4-es-data
         persistentVolumeClaim:
-          claimName: {{ include "georchestra.fullname" . }}-gn4-es-data
+          claimName: {{ .Values.georchestra.storage.gn4_es.existingClaim | default (print (include "georchestra.fullname" .) "-gn4-es-data") }}
       {{- if $webapp.tolerations }}
       tolerations:
         {{- $webapp.tolerations | toYaml | nindent 8 }}

--- a/templates/geonetwork/geonetwork-datadir-pvc.yaml
+++ b/templates/geonetwork/geonetwork-datadir-pvc.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork -}}
 {{- $webapp_storage := .Values.georchestra.storage.geonetwork_datadir -}}
-{{- if $webapp.enabled -}}
+{{- if and $webapp.enabled (not $webapp_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/geonetwork/geonetwork-deployment.yaml
+++ b/templates/geonetwork/geonetwork-deployment.yaml
@@ -97,7 +97,7 @@ spec:
         emptyDir: {}
       - name: geonetwork-datadir
         persistentVolumeClaim:
-          claimName: {{ include "georchestra.fullname" . }}-geonetwork-datadir
+          claimName: {{ .Values.georchestra.storage.geonetwork_datadir.existingClaim | default (print (include "georchestra.fullname" .) "-geonetwork-datadir") }}
       {{- if .Values.georchestra.datadir.git.ssh_secret }}
       - name: ssh-secret
         secret:

--- a/templates/geonetwork/housekeeping/clean-harvester-logs.yaml
+++ b/templates/geonetwork/housekeeping/clean-harvester-logs.yaml
@@ -32,7 +32,7 @@ spec:
           volumes:
           - name: geonetwork-datadir
             persistentVolumeClaim:
-              claimName: {{ include "georchestra.fullname" . }}-geonetwork-datadir
+              claimName: {{ .Values.georchestra.storage.geonetwork_datadir.existingClaim | default (print (include "georchestra.fullname" .) "-geonetwork-datadir") }}
           restartPolicy: OnFailure
           {{- if $webapp.housekeeping.tolerations }}
           tolerations:

--- a/templates/geoserver/geoserver-datadir-pvc.yaml
+++ b/templates/geoserver/geoserver-datadir-pvc.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geoserver -}}
 {{- $webapp_storage := .Values.georchestra.storage.geoserver_datadir -}}
-{{- if $webapp.enabled -}}
+{{- if and $webapp.enabled (not $webapp_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -231,13 +231,13 @@ spec:
         emptyDir: {}
       - name: geoserver-tiles
         persistentVolumeClaim:
-          claimName: {{ include "georchestra.fullname" . }}-geoserver-tiles
+          claimName: {{ .Values.georchestra.storage.geoserver_tiles.existingClaim | default (print (include "georchestra.fullname" .) "-geoserver-tiles") }}
       - name: geoserver-geodata
         persistentVolumeClaim:
-          claimName: {{ include "georchestra.fullname" . }}-geoserver-geodata
+          claimName: {{ .Values.georchestra.storage.geoserver_geodata.existingClaim | default (print (include "georchestra.fullname" .) "-geoserver-geodata") }}
       - name: geoserver-datadir
         persistentVolumeClaim:
-          claimName: {{ include "georchestra.fullname" . }}-geoserver-datadir
+          claimName: {{ .Values.georchestra.storage.geoserver_datadir.existingClaim | default (print (include "georchestra.fullname" .) "-geoserver-datadir") }}
       {{- if .Values.georchestra.datadir.git.ssh_secret }}
       - name: ssh-secret
         secret:

--- a/templates/geoserver/geoserver-geodata-pvc.yaml
+++ b/templates/geoserver/geoserver-geodata-pvc.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geoserver -}}
 {{- $webapp_storage := .Values.georchestra.storage.geoserver_geodata -}}
-{{- if $webapp.enabled -}}
+{{- if and $webapp.enabled (not $webapp_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/geoserver/geoserver-tiles-pvc.yaml
+++ b/templates/geoserver/geoserver-tiles-pvc.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geoserver -}}
 {{- $webapp_storage := .Values.georchestra.storage.geoserver_tiles -}}
-{{- if and $webapp.enabled .Values.georchestra.storage.geoserver_tiles -}}
+{{- if and $webapp.enabled .Values.georchestra.storage.geoserver_tiles (not $webapp_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/geowebcache/geowebcache-deployment.yaml
+++ b/templates/geowebcache/geowebcache-deployment.yaml
@@ -92,7 +92,7 @@ spec:
         emptyDir: {}
       - name: geowebcache-tiles
         persistentVolumeClaim:
-          claimName: {{ include "georchestra.fullname" . }}-geowebcache-tiles
+          claimName: {{ .Values.georchestra.storage.geowebcache_tiles.existingClaim | default (print (include "georchestra.fullname" .) "-geowebcache-tiles") }}
       {{- if .Values.georchestra.datadir.git.ssh_secret }}
       - name: ssh-secret
         secret:

--- a/templates/geowebcache/geowebcache-tiles-pvc.yaml
+++ b/templates/geowebcache/geowebcache-tiles-pvc.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geowebcache -}}
 {{- $webapp_storage := .Values.georchestra.storage.geowebcache_tiles -}}
-{{- if and $webapp.enabled .Values.georchestra.storage.geowebcache_tiles -}}
+{{- if and $webapp.enabled .Values.georchestra.storage.geowebcache_tiles (not $webapp_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/ldap/openldap-deployment.yaml
+++ b/templates/ldap/openldap-deployment.yaml
@@ -73,10 +73,10 @@ spec:
       volumes:
       - name: openldap-data
         persistentVolumeClaim:
-          claimName: {{ include "georchestra.fullname" . }}-openldap-data
+          claimName: {{ .Values.georchestra.storage.openldap_data.existingClaim | default (print (include "georchestra.fullname" .) "-openldap-data") }}
       - name: openldap-config
         persistentVolumeClaim:
-          claimName: {{ include "georchestra.fullname" . }}-openldap-config
+          claimName: {{ .Values.georchestra.storage.openldap_config.existingClaim | default (print (include "georchestra.fullname" .) "-openldap-config") }}
       {{- if $webapp.extraVolumes }}
           {{- toYaml $webapp.extraVolumes | nindent 6 }}
       {{- end }}

--- a/templates/ldap/openldap-pvc-config.yaml
+++ b/templates/ldap/openldap-pvc-config.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.openldap -}}
 {{- $webapp_storage := .Values.georchestra.storage.openldap_config -}}
-{{- if $webapp.enabled -}}
+{{- if and $webapp.enabled (not $webapp_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/ldap/openldap-pvc-data.yaml
+++ b/templates/ldap/openldap-pvc-data.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.openldap -}}
 {{- $webapp_storage := .Values.georchestra.storage.openldap_data -}}
-{{- if $webapp.enabled -}}
+{{- if and $webapp.enabled (not $webapp_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/mapstore/mapstore-deployment.yaml
+++ b/templates/mapstore/mapstore-deployment.yaml
@@ -79,7 +79,7 @@ spec:
         emptyDir: {}
       - name: mapstore-datadir
         persistentVolumeClaim:
-          claimName: {{ include "georchestra.fullname" . }}-mapstore-datadir
+          claimName: {{ .Values.georchestra.storage.mapstore_datadir.existingClaim | default (print (include "georchestra.fullname" .) "-mapstore-datadir") }}
       {{- if .Values.georchestra.datadir.git.ssh_secret }}
       - name: ssh-secret
         secret:

--- a/templates/mapstore/mapstore-pvc.yaml
+++ b/templates/mapstore/mapstore-pvc.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.mapstore -}}
 {{- $webapp_storage := .Values.georchestra.storage.mapstore_datadir -}}
-{{- if $webapp.enabled -}}
+{{- if and $webapp.enabled (not $webapp_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/templates/rabbitmq/rabbitmq-pvc.yaml
+++ b/templates/rabbitmq/rabbitmq-pvc.yaml
@@ -1,6 +1,6 @@
 {{- $rabbitmq := .Values.rabbitmq -}}
-{{- $rabbitmq_storage := .Values.georchestra.storage.mapstore_datadir -}}
-{{- if and $rabbitmq.enabled $rabbitmq.storage -}}
+{{- $rabbitmq_storage := .Values.rabbitmq.storage -}}
+{{- if and $rabbitmq.enabled $rabbitmq.storage (not $rabbitmq_storage.existingClaim) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -217,8 +217,10 @@ georchestra:
   # Some cloud providers automatically create & assign PVs to PVCs
   # some other need to create a PV first ; if so, then you can
   # uncomment the `pv_name` entries below.
+  # You can use existingClaim to provide the name of an existing PVC to use for persistence
   storage:
     gn4_es:
+      # existingClaim: gn4-es-data
       # pv_name: gn4_es_data
       size: 2Gi
     geonetwork_datadir:


### PR DESCRIPTION
This PR add the ability to provide the name of an existing PVC to use for persistence.

Here I use LongHorn to manage PV/PVC, so I need this ability if I want to setup persistence.