### PR TITLE
Selective sync process

### DIFF
--- a/templates/datadirsync/datadirsync-configmap.yaml
+++ b/templates/datadirsync/datadirsync-configmap.yaml
@@ -1,0 +1,12 @@
+{{- $webapp := .Values.georchestra.datadirsync  -}}
+{{- $fullname := include "georchestra.fullname" . -}}
+{{- if $webapp.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $fullname }}-datadirsync-cm
+data:
+  rollout_mapping_config.yaml: |
+    "*":
+      - {{ $fullname }}-geoserver
+{{- end }}

--- a/templates/datadirsync/datadirsync-configmap.yaml
+++ b/templates/datadirsync/datadirsync-configmap.yaml
@@ -1,4 +1,4 @@
-{{- $webapp := .Values.georchestra.datadirsync  -}}
+{{- $webapp := .Values.georchestra.datadirsync -}}
 {{- $fullname := include "georchestra.fullname" . -}}
 {{- if $webapp.enabled -}}
 apiVersion: v1
@@ -7,6 +7,10 @@ metadata:
   name: {{ $fullname }}-datadirsync-cm
 data:
   rollout_mapping_config.yaml: |
-    "*":
-      - {{ $fullname }}-geoserver
+{{- range $key, $values := $webapp.rolloutDeploymentsMapping }}
+    "{{ $key }}":
+{{- range $values }}
+      - {{ $fullname }}-{{ . }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/templates/datadirsync/datadirsync-deployment.yaml
+++ b/templates/datadirsync/datadirsync-deployment.yaml
@@ -35,32 +35,36 @@ spec:
           value: "{{ .Values.georchestra.datadir.git.ref }}"
         - name: POLL_INTERVAL
           value: "{{ $webapp.pollInterval }}"
-        - name: ROLLOUT_DEPLOYMENTS
-          value: |
-            {{ $prefix := include "georchestra.fullname" . -}}
-            {{ $suffixes := $webapp.deploymentSuffixNameList -}}
-            {{ $deployments := list -}}
-            {{- range $suffix := $suffixes }}
-            {{ $deployments = append $deployments (printf "%s-%s" $prefix $suffix) }}
-            {{- end -}}
-            {{- join ", " $deployments }}
+        - name: ROLLOUT_MAPPING_FILE
+          value: "/tmp/datadirsync/rollout_mapping_config.yaml"
         - name: ROLLOUT_NAMESPACE
           value: "{{ .Release.Namespace }}"
       {{- if .Values.georchestra.datadir.git.ssh_secret }}
         - name: GIT_SSH_COMMAND
           value: ssh -i /id_rsa -o "IdentitiesOnly=yes" -o "StrictHostKeyChecking=no"
+      {{- end }}
         volumeMounts:
+        - name: rollout-configuration-mapping
+          mountPath: /tmp/datadirsync
+          readOnly: true
+      {{- if .Values.georchestra.datadir.git.ssh_secret }}
         - name: ssh-secret
           mountPath: /id_rsa
           # It's assumed that a subpath ssh-privatekey is in the secret (with the content of the file)
           subPath: ssh-privatekey
           readOnly: true
+      {{- end }}
       volumes:
+      - name: rollout-configuration-mapping
+        configMap:
+          name: {{ include "georchestra.fullname" . }}-datadirsync-cm
+      {{- if .Values.georchestra.datadir.git.ssh_secret }}
       - name: ssh-secret
         secret:
           secretName: {{ .Values.georchestra.datadir.git.ssh_secret }}
           defaultMode: 0440
       {{- end }}
+
       {{- if $webapp.registry_secret }}
       imagePullSecrets:
       - name: {{ $webapp.registry_secret }}

--- a/templates/datadirsync/datadirsync-role.yaml
+++ b/templates/datadirsync/datadirsync-role.yaml
@@ -8,11 +8,15 @@ metadata:
 rules:
   - apiGroups: ["apps"]
     resources: ["pods", "replicasets", "deployments"]
-    resourceNames: [{{- $prefix := include "georchestra.fullname" . -}}
-      {{- $suffixes := $webapp.deploymentSuffixNameList -}}
+    resourceNames:
+      {{- $prefix := include "georchestra.fullname" . -}}
       {{- $deployments := list -}}
-      {{- range $index, $suffix := $suffixes }}
-      {{ if $index }}, {{ end }}"{{ printf "%s-%s" $prefix $suffix }}"
+      {{- range $key, $values := $webapp.rolloutDeploymentsMapping }}
+        {{- $deployments = concat $deployments $values }}
+      {{- end }}
+      {{- $deployments = mustUniq $deployments }}
+      [{{- range $index, $item := $deployments }}
+        {{- if $index }}, {{ end }}"{{ printf "%s-%s" $prefix $item }}"
       {{- end }}]
     verbs: ["get", "patch"]
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -372,6 +372,10 @@ georchestra:
     image: georchestra/datadirsync-k8s-agent:1.4.0
     pollInterval: 30
     tolerations: []
+    # when using wildcard, you need to use "", otherwise it's not necessary
+    rolloutDeploymentsMapping:
+      "*":
+        - geoserver
     # registry_secret: default
 
 fqdn: "georchestra-127-0-1-1.traefik.me"

--- a/values.yaml
+++ b/values.yaml
@@ -369,12 +369,10 @@ georchestra:
         memory: 64Mi
   datadirsync:
     enabled: false
-    image: georchestra/datadirsync-k8s-agent:1.3.3
+    image: georchestra/datadirsync-k8s-agent:1.4.0
     pollInterval: 30
     tolerations: []
     # registry_secret: default
-    deploymentSuffixNameList:
-      - geoserver
 
 fqdn: "georchestra-127-0-1-1.traefik.me"
 


### PR DESCRIPTION
Selective sync process. Rollout of deployments is now based on a yaml file which includes the chance to determine which folders/files changes would affect a rollout on the different deployments.
A sample:
```
  rollout_mapping_config.yaml: |
    "*":
      - {{ $fullname }}-geoserver
```

That configuration on the mapping file, allows to rollout the deployment  {{ $fullname }}-geoserver  based on any update on the repository (using wildcard *)
In case you want something more selective, you can do something like:
```
  rollout_mapping_config.yaml: |
    "default.properties":
      - {{ $fullname }}-geoserver
      - {{ $fullname }}-header
    "console":
      - {{ $fullname }}-console
```
which in turns would rollout geoserver and header components, when default.properties file changes, and a rollout on console when some change in folder console happens.


