### PR TITLE
[Mapstore] Use JAVA_OPTIONS and raise failureThreshold

### DIFF
--- a/templates/mapstore/mapstore-deployment.yaml
+++ b/templates/mapstore/mapstore-deployment.yaml
@@ -49,7 +49,7 @@ spec:
           - mountPath: /mnt/mapstore2
             name: mapstore-datadir
         env:
-          - name: JAVA_OPTS
+          - name: JAVA_OPTIONS
             value: -DPRINT_BASE_URL=pdf -Dgeorchestra.datadir=/etc/georchestra -Dgeorchestra.extensions=/mnt/mapstore2
           {{- include "georchestra.ldap-envs" . | nindent 10 }}
           {{- include "georchestra.database-georchestra-envs" . | nindent 10 }}
@@ -72,7 +72,7 @@ spec:
           httpGet:
             path: /mapstore/configs/config.json
             port: 8080
-          failureThreshold: 5
+          failureThreshold: 20
           periodSeconds: 15
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}


### PR DESCRIPTION
We have to use `JAVA_OPTIONS` instead of `JAVA_OPTS` to not erase the Docker container values.

Also I raise the `failureThreshold` to `20` (5 minutes) as it can fail with huge LDAP as Mapstore init time depends on users amount.