### PR TITLE
chore: switch image parameter to dedicated section

### DIFF
--- a/georchestra/templates/_helpers.tpl
+++ b/georchestra/templates/_helpers.tpl
@@ -60,3 +60,28 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Get the image for a webapp with backward compatibility for docker_image
+Usage: {{ include "georchestra.webappImage" $webapp }}
+Returns the full image string (repository:tag)
+*/}}
+{{- define "georchestra.webappImage" -}}
+{{- if .docker_image -}}
+{{- .docker_image -}}
+{{- else -}}
+{{- printf "%s:%s" .image.repository .image.tag -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Get the image pull policy for a webapp with backward compatibility
+Usage: {{ include "georchestra.webappImagePullPolicy" $webapp }}
+*/}}
+{{- define "georchestra.webappImagePullPolicy" -}}
+{{- if .docker_image -}}
+IfNotPresent
+{{- else -}}
+{{- .image.pullPolicy | default "IfNotPresent" -}}
+{{- end -}}
+{{- end -}}

--- a/georchestra/templates/analytics/analytics-deployment.yaml
+++ b/georchestra/templates/analytics/analytics-deployment.yaml
@@ -34,8 +34,8 @@ spec:
       {{- include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       containers:
       - name: georchestra-analytics
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           {{- include "georchestra.database-georchestra-envs" . | nindent 10 }}
           {{- if $webapp.extra_environment }}

--- a/georchestra/templates/cas/cas-deployment.yaml
+++ b/georchestra/templates/cas/cas-deployment.yaml
@@ -34,8 +34,8 @@ spec:
       {{- include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       containers:
       - name: georchestra-cas
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           {{- include "georchestra.common-envs" . | nindent 10 }}
           {{- include "georchestra.ldap-envs" . | nindent 10 }}

--- a/georchestra/templates/console/console-deployment.yaml
+++ b/georchestra/templates/console/console-deployment.yaml
@@ -34,8 +34,8 @@ spec:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       containers:
       - name: georchestra-console
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           {{- include "georchestra.common-envs" . | nindent 10 }}
           {{- include "georchestra.ldap-envs" . | nindent 10 }}

--- a/georchestra/templates/datafeeder/datafeeder-deployment.yaml
+++ b/georchestra/templates/datafeeder/datafeeder-deployment.yaml
@@ -53,8 +53,8 @@ spec:
 
       containers:
       - name: georchestra-datafeeder
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           - name: GEONETWORK_HOST
             value: "{{ include "georchestra.fullname" . }}-geonetwork-svc"

--- a/georchestra/templates/datafeeder/import-deployment.yaml
+++ b/georchestra/templates/datafeeder/import-deployment.yaml
@@ -34,8 +34,8 @@ spec:
       {{- include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       containers:
       - name: georchestra-import
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         {{- if $webapp.extra_environment }}
         env:
           {{- $webapp.extra_environment | toYaml | nindent 10 }}

--- a/georchestra/templates/gateway/gateway-deployment.yaml
+++ b/georchestra/templates/gateway/gateway-deployment.yaml
@@ -34,8 +34,8 @@ spec:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       containers:
       - name: georchestra-gateway
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           - name: JAVA_TOOL_OPTIONS
             value: {{ $webapp.environment.JAVA_TOOL_OPTIONS }}

--- a/georchestra/templates/geonetwork/elasticsearch/es-deployment.yaml
+++ b/georchestra/templates/geonetwork/elasticsearch/es-deployment.yaml
@@ -36,8 +36,8 @@ spec:
         fsGroup: 1000
       containers:
       - name: elasticsearch
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           - name: ES_JAVA_OPTS
             value: -Dlog4j2.formatMsgNoLookups=true -Dlog4j2.disable.jmx=true

--- a/georchestra/templates/geonetwork/geonetwork-deployment.yaml
+++ b/georchestra/templates/geonetwork/geonetwork-deployment.yaml
@@ -39,8 +39,8 @@ spec:
       {{ include "georchestra.bootstrap_georchestra_datadir" $ | nindent 6 }}
       containers:
       - name: georchestra-geonetwork
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir

--- a/georchestra/templates/geonetwork/kibana/kibana-deployment.yaml
+++ b/georchestra/templates/geonetwork/kibana/kibana-deployment.yaml
@@ -32,8 +32,8 @@ spec:
         {{- end }}
       containers:
       - name: kibana
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           - name: ELASTICSEARCH_HOSTS
             value: http://{{ include "georchestra.fullname" . }}-gn4-elasticsearch-svc:9200

--- a/georchestra/templates/geonetwork/ogc-api-records/ogc-api-records-deployment.yaml
+++ b/georchestra/templates/geonetwork/ogc-api-records/ogc-api-records-deployment.yaml
@@ -56,8 +56,8 @@ spec:
 
       containers:
       - name: ogc-api-records
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           - name: LANG
             value: en_US.UTF-8

--- a/georchestra/templates/geoserver/geoserver-deployment.yaml
+++ b/georchestra/templates/geoserver/geoserver-deployment.yaml
@@ -40,8 +40,8 @@ spec:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       containers:
       - name: georchestra-geoserver
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           {{ if $database.builtin }}
           - name: GEODATA_PGHOST

--- a/georchestra/templates/geowebcache/geowebcache-deployment.yaml
+++ b/georchestra/templates/geowebcache/geowebcache-deployment.yaml
@@ -55,8 +55,8 @@ spec:
 
       containers:
       - name: georchestra-geowebcache
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           {{- include "georchestra.common-envs" . | nindent 10 }}
           {{- include "georchestra.database-georchestra-envs" . | nindent 10 }}

--- a/georchestra/templates/header/header-deployment.yaml
+++ b/georchestra/templates/header/header-deployment.yaml
@@ -34,8 +34,8 @@ spec:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       containers:
       - name: georchestra-header
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         resources:
           requests:
             cpu: 100m

--- a/georchestra/templates/ldap/openldap-deployment.yaml
+++ b/georchestra/templates/ldap/openldap-deployment.yaml
@@ -34,8 +34,8 @@ spec:
         {{- end }}
       containers:
       - name: georchestra-ldap
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           - name: SLAPD_ORGANISATION
             value: georchestra

--- a/georchestra/templates/mapstore/mapstore-deployment.yaml
+++ b/georchestra/templates/mapstore/mapstore-deployment.yaml
@@ -36,8 +36,8 @@ spec:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       containers:
       - name: georchestra-mapstore
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         {{ if and $webapp.command $webapp.args -}}
         command:
         {{- range $webapp.command }}

--- a/georchestra/templates/security-proxy/security-proxy-deployment.yaml
+++ b/georchestra/templates/security-proxy/security-proxy-deployment.yaml
@@ -51,8 +51,8 @@ spec:
 
       containers:
       - name: georchestra-sp
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           {{- include "georchestra.service-envs" . | nindent 10 }}
           {{- include "georchestra.common-envs" . | nindent 10 }}

--- a/georchestra/templates/smtp-smarthost/smtp-deployment.yaml
+++ b/georchestra/templates/smtp-smarthost/smtp-deployment.yaml
@@ -32,8 +32,8 @@ spec:
         {{- end }}
       containers:
       - name: georchestra-smtp
-        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
-        imagePullPolicy: {{ $webapp.image.pullPolicy | default "IfNotPresent" }}
+        image: {{ include "georchestra.webappImage" $webapp }}
+        imagePullPolicy: {{ include "georchestra.webappImagePullPolicy" $webapp }}
         env:
           {{- if $webapp.relay_host }}
           - name: RELAY_HOST

--- a/georchestra/values.yaml
+++ b/georchestra/values.yaml
@@ -119,7 +119,6 @@ georchestra:
         repository: georchestra/geonetwork
         pullPolicy: IfNotPresent
         tag: latest
-      jetty_monitoring: false
       # the registry secret is only used for the GeoNetwork image
       # registry_secret: default
       extra_environment: []
@@ -213,7 +212,6 @@ georchestra:
         repository: georchestra/geoserver
         pullPolicy: IfNotPresent
         tag: latest
-      jetty_monitoring: false
       extra_environment: []
       # volumes is the deployment-compliant specification of the pod's extra volume
       # It should match with an item from the extra_volumeName.name variable below.
@@ -324,7 +322,6 @@ georchestra:
         repository: georchestra/security-proxy
         pullPolicy: IfNotPresent
         tag: latest
-      jetty_monitoring: false
       extra_environment: []
       # registry_secret: default
       envsubst:
@@ -426,7 +423,6 @@ georchestra:
         memory: 64Mi
       limits:
         memory: 64Mi
-  datadirsync:
 
 fqdn: "georchestra-127-0-0-1.nip.io"
 


### PR DESCRIPTION
- Switch to a dedicated image section:
  - Allows to keep the default parameter from the upstream helm chart. Like repository, this way if a change in made where the docker image is hosted, all the infra will get these changes by just updating the helm chart.
- Switch to pullPolicy IfNotPresent in order to avoid by default pulling a new helm chart when unnecessary (production for example).