### PR TITLE
uncomment default param for rolloutDeploymentsMapping

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -373,7 +373,7 @@ georchestra:
     pollInterval: 30
     tolerations: []
     # when using wildcard, you need to use "", otherwise it's not necessary
-    #rolloutDeploymentsMapping:
+    # rolloutDeploymentsMapping:
     #  "*":
     #    - geoserver
     # registry_secret: default

--- a/values.yaml
+++ b/values.yaml
@@ -373,9 +373,9 @@ georchestra:
     pollInterval: 30
     tolerations: []
     # when using wildcard, you need to use "", otherwise it's not necessary
-    rolloutDeploymentsMapping:
-      "*":
-        - geoserver
+    #rolloutDeploymentsMapping:
+    #  "*":
+    #    - geoserver
     # registry_secret: default
 
 fqdn: "georchestra-127-0-1-1.traefik.me"


### PR DESCRIPTION
If we set a default value then we will have this value by default for everyone unless we override the "*" value.

So we should comment instead.

```diff
+ # Source: georchestra/templates/datadirsync/datadirsync-configmap.yaml
+ apiVersion: v1
+ kind: ConfigMap
+ metadata:
+   name: georchestra-datadirsync-cm
+ data:
+   rollout_mapping_config.yaml: |
+     "*":
+       - georchestra-geoserver
+     "geonetwork":
+       - georchestra-geonetwork
+     "geoserver":
+       - georchestra-geoserver
+     "geowebcache":
+       - georchestra-geowebcache
+     "header":
+       - georchestra-header
+     "mapstore":
+       - georchestra-mapstore
+     "security-proxy":
+       - georchestra-sp
```