### PR TITLE
chore: add ability to customize the bitnami/git image used

### DIFF
--- a/templates/_bootstrap-georchestra-datadir.tpl
+++ b/templates/_bootstrap-georchestra-datadir.tpl
@@ -1,6 +1,6 @@
 {{- define "georchestra.bootstrap_georchestra_datadir" -}}
 - name: bootstrap-georchestra-datadir
-  image: bitnami/git
+  image: "{{ .Values.georchestra.datadir.image.repository }}:{{ .Values.georchestra.datadir.image.tag }}"
   command:
   - /bin/sh
   - -c

--- a/values.yaml
+++ b/values.yaml
@@ -302,6 +302,9 @@ georchestra:
           cpu: 4000m
           memory: 1Gi
   datadir:
+    image:
+      repository: bitnami/git
+      tag: 2
     volume:
     - name: georchestra-datadir
       emptyDir: {}


### PR DESCRIPTION
In certain scenario, you may need to customize the bitnami/git image used.

- Because you are in a restricted environment that use a registry proxy.
- Because you want to use a proxy in order to not be affected by Docker hub limits.