### PR TITLE
fix: Remove geoserver_tiles fix-permissions-pvc initcontainer

### DIFF
--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -42,8 +42,6 @@ spec:
           name: geoserver-datadir
         - mountPath: /mnt/geoserver_geodata
           name: geoserver-geodata
-        - mountPath: /mnt/geoserver_tiles
-          name: geoserver-tiles
       containers:
       - name: georchestra-geoserver
         image: {{ $webapp.docker_image }}

--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -36,7 +36,7 @@ spec:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
       - name: fix-permissions-pvc
         image: "{{ .Values.tooling.general.image.repository }}:{{ .Values.tooling.general.image.tag }}"
-        command: ["sh", "-c", "chown -R 999:999 /mnt/geoserver_datadir /mnt/geoserver_geodata /mnt/geoserver_tiles"]
+        command: ["sh", "-c", "chown -R 999:999 /mnt/geoserver_datadir /mnt/geoserver_geodata"]
         volumeMounts:
         - mountPath: /mnt/geoserver_datadir
           name: geoserver-datadir


### PR DESCRIPTION
Remove geoserver_tiles from chown 999 as it can take way too much time to finish depending of ammount of files. 

@jeanmi151 told me it was a good idea to have it here