### PR TITLE
fix: control flow geoserver priority healthcheck

### DIFF
--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -195,7 +195,7 @@ spec:
             port: 8080
             httpHeaders:
             - name: ctrl-flow-priority
-              value: "true"
+              value: "10"
           periodSeconds: 10
           timeoutSeconds: 5
         {{- end }}


### PR DESCRIPTION
"ctrl-flow-priority: true" is incorrect. According to the [geoserver doc](https://docs.geoserver.org/main/en/user/extensions/controlflow/index.html#request-priority-support), geoserver expect a number not a boolean.

Thanks AI for the help :smile:
![image](https://github.com/user-attachments/assets/04dd68ba-1e40-4e1b-877a-ba5470e3ec31)

cc @jeanmi151 