### PR TITLE
Add extra env to Elasticsearch

### DIFF
--- a/templates/geonetwork/elasticsearch/es-deployment.yaml
+++ b/templates/geonetwork/elasticsearch/es-deployment.yaml
@@ -44,6 +44,9 @@ spec:
             value: -Dlog4j2.formatMsgNoLookups=true -Dlog4j2.disable.jmx=true
           - name: discovery.type
             value: single-node
+          {{- if $webapp.extra_environment }}
+          {{- $webapp.extra_environment | toYaml | nindent 10 }}
+          {{- end }}
         ports:
         - containerPort: 9200
           name: elastic


### PR DESCRIPTION
As Elasticsearch 8 will need env vars :
- name: xpack.security.enabled
value: false
- name: xpack.security.enrollment.enabled
value: false

