### PR TITLE
add xpack support with auth + healthcheck es & kibana

### DIFF
--- a/templates/_helpers-envs.tpl
+++ b/templates/_helpers-envs.tpl
@@ -27,13 +27,13 @@ Insert service host environment variables
 - name: OGC_API_RECORDS_HOST
   value: "{{ include "georchestra.fullname" . }}-gn4-ogc-api-records-svc"
 - name: ES_HOST
-  value: "{{ include "georchestra.fullname" . }}-gn4-elasticsearch-svc"
+  value: "{{ .Values.elasticsearch.host | default (include "georchestra.fullname" .) }}-gn4-elasticsearch-svc"
 - name: ES_PORT
-  value: "9200"
+  value: "{{ .Values.elasticsearch.port | default 9200 }}"
 - name: KB_HOST
-  value: "{{ include "georchestra.fullname" . }}-gn4-kibana-svc"
+  value: "{{ .Values.georchestra.webapps.geonetwork.kibana.host | default (include "georchestra.fullname" .) }}-gn4-kibana-svc"
 - name: KB_PORT
-  value: "5601"
+  value: "{{ .Values.georchestra.webapps.geonetwork.kibana.port | default 5601 }}"
 {{- end }}
 
 {{/*

--- a/templates/geonetwork/elasticsearch/es-deployment.yaml
+++ b/templates/geonetwork/elasticsearch/es-deployment.yaml
@@ -44,6 +44,10 @@ spec:
             value: -Dlog4j2.formatMsgNoLookups=true -Dlog4j2.disable.jmx=true
           - name: discovery.type
             value: single-node
+          - name: xpack.security.transport.ssl.enabled
+            value: "false"
+          - name: xpack.security.http.ssl.enabled
+            value: "false"
           - name: ELASTIC_PASSWORD
             value: {{ $webapp.elasticPassword | quote }}
         ports:

--- a/templates/geonetwork/elasticsearch/es-deployment.yaml
+++ b/templates/geonetwork/elasticsearch/es-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork.elasticsearch -}}
-{{- if .Values.georchestra.webapps.geonetwork.enabled -}}
+{{- if and .Values.georchestra.webapps.geonetwork.enabled $webapp.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -44,9 +44,35 @@ spec:
             value: -Dlog4j2.formatMsgNoLookups=true -Dlog4j2.disable.jmx=true
           - name: discovery.type
             value: single-node
+          - name: ELASTIC_PASSWORD
+            value: {{ $webapp.elasticPassword | quote }}
         ports:
         - containerPort: 9200
           name: elastic
+        livenessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - 'curl -u elastic:$ELASTIC_PASSWORD -fsSL http://localhost:9200/_cluster/health > /dev/null'
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+          successThreshold: 1
+        readinessProbe:
+          exec:
+            command:
+              - sh
+              - -c
+              - |
+                status=$(curl -u elastic:$ELASTIC_PASSWORD -fsSL http://localhost:9200/_cluster/health | grep -oP '"status":"\K[^"]+')
+                [ "$status" = "green" ] || [ "$status" = "yellow" ]
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
+          successThreshold: 1
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: gn4-es-data

--- a/templates/geonetwork/geonetwork-deployment.yaml
+++ b/templates/geonetwork/geonetwork-deployment.yaml
@@ -56,6 +56,10 @@ spec:
         env:
           {{- include "georchestra.database-georchestra-envs" . | nindent 10  }}
           {{- include "georchestra.service-envs" . | nindent 10 }}
+          - name: ES_USERNAME
+            value: {{ .Values.elasticsearch.username | default "elastic" | quote }}
+          - name: ES_PASSWORD
+            value: {{ .Values.elasticsearch.password | default $webapp.elasticPassword | quote }}
           {{- if $webapp.extra_environment }}
           {{- $webapp.extra_environment | toYaml | nindent 10 }}
           {{- end }}

--- a/templates/geonetwork/kibana/kibana-deployment.yaml
+++ b/templates/geonetwork/kibana/kibana-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork.kibana -}}
-{{- if .Values.georchestra.webapps.geonetwork.enabled -}}
+{{- if and .Values.georchestra.webapps.geonetwork.enabled .Values.georchestra.webapps.geonetwork.elasticsearch.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -31,9 +31,31 @@ spec:
         env:
           - name: ELASTICSEARCH_HOSTS
             value: http://{{ include "georchestra.fullname" . }}-gn4-elasticsearch-svc:9200
+          - name: ELASTICSEARCH_USERNAME
+            value: "elastic"
+          - name: ELASTICSEARCH_PASSWORD
+            value: {{ .Values.georchestra.webapps.geonetwork.elasticsearch.elasticPassword | quote }}
         ports:
         - containerPort: 5601
           name: kibana
+        livenessProbe:
+          httpGet:
+            path: /api/status
+            port: kibana
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 3
+        readinessProbe:
+          httpGet:
+            path: /api/status
+            port: kibana
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 5
+          timeoutSeconds: 3
+          failureThreshold: 3
         volumeMounts:
           - mountPath: /usr/share/kibana/config
             name: gn4-kibana-config

--- a/templates/geonetwork/kibana/kibana-deployment.yaml
+++ b/templates/geonetwork/kibana/kibana-deployment.yaml
@@ -1,5 +1,5 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork.kibana -}}
-{{- if and .Values.georchestra.webapps.geonetwork.enabled .Values.georchestra.webapps.geonetwork.elasticsearch.enabled -}}
+{{- if and .Values.georchestra.webapps.geonetwork.enabled $webapp.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,9 +32,9 @@ spec:
           - name: ELASTICSEARCH_HOSTS
             value: http://{{ include "georchestra.fullname" . }}-gn4-elasticsearch-svc:9200
           - name: ELASTICSEARCH_USERNAME
-            value: "elastic"
+            value: "kibana_system"
           - name: ELASTICSEARCH_PASSWORD
-            value: {{ .Values.georchestra.webapps.geonetwork.elasticsearch.elasticPassword | quote }}
+            value: {{ $webapp.kibanaSystemPassword | quote }}
         ports:
         - containerPort: 5601
           name: kibana

--- a/values.yaml
+++ b/values.yaml
@@ -136,7 +136,6 @@ georchestra:
           limits:
             memory: 1Gi
       elasticsearch:
-        # if not enabled, also disable kibana deployment
         enabled: true
         replicaCount: "1"
         image: docker.elastic.co/elasticsearch/elasticsearch:7.17.21
@@ -152,11 +151,14 @@ georchestra:
             cpu: 2000m
             memory: 1512Mi
       kibana:
+        enabled: false
         replicaCount: "1"
         image: docker.elastic.co/kibana/kibana:7.15.1
         service:
           annotations: {}
         tolerations: []
+        # The password that you set using bin/elasticsearch-reset-password -u kibana_system
+        kibanaSystemPassword: ""
         resources:
           requests:
             cpu: 100m
@@ -164,8 +166,8 @@ georchestra:
           limits:
             memory: 1Gi
         # For configuring external kibana with geonetwork
-        #host: mykibana
-        #port: myport
+        # host: mykibana
+        # port: myport
       # automatically clean some logs of geonetwork
       housekeeping:
         harvester_logs:

--- a/values.yaml
+++ b/values.yaml
@@ -136,11 +136,14 @@ georchestra:
           limits:
             memory: 1Gi
       elasticsearch:
+        # if not enabled, also disable kibana deployment
+        enabled: true
         replicaCount: "1"
         image: docker.elastic.co/elasticsearch/elasticsearch:7.17.21
         service:
           annotations: {}
         tolerations: []
+        elasticPassword: changeme
         resources:
           requests:
             cpu: 200m
@@ -160,6 +163,9 @@ georchestra:
             memory: 1Gi
           limits:
             memory: 1Gi
+        # For configuring external kibana with geonetwork
+        #host: mykibana
+        #port: myport
       # automatically clean some logs of geonetwork
       housekeeping:
         harvester_logs:
@@ -417,6 +423,14 @@ ldap:
   # Optionally, you can also provide the GEORCHESTRA_PRIVILEGED_USER_PASSWORD env var, that will
   # be used to replace the default one on first run, see https://github.com/georchestra/georchestra/blob/master/ldap/docker-root/docker-entrypoint.d/01-populate#L47-L54
   # existingSecret: mysecretldapenvvars
+
+# When using external ElasticSearch
+# Set parameters used by the apps (only geonetwork for now)
+elasticsearch: {}
+  # host: myhost
+  # port: myport
+  # username: myusername
+  # password: mypassword
 
 database:
   builtin: true

--- a/values.yaml
+++ b/values.yaml
@@ -138,10 +138,11 @@ georchestra:
       elasticsearch:
         enabled: true
         replicaCount: "1"
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.17.21
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.14.3
         service:
           annotations: {}
         tolerations: []
+        # Password of the elastic user
         elasticPassword: changeme
         resources:
           requests:
@@ -153,7 +154,7 @@ georchestra:
       kibana:
         enabled: false
         replicaCount: "1"
-        image: docker.elastic.co/kibana/kibana:7.15.1
+        image: docker.elastic.co/kibana/kibana:8.14.3
         service:
           annotations: {}
         tolerations: []


### PR DESCRIPTION
- Add default password for elastic username using xpack and allow to configure it.
- Allow to provide credentials for external elastic + external kibana
- Add healthchecks for elasticsearch and kibana
- Disable kibana by default because it's not possible to configure xpack with a kibana password through environment variables. 

----

close #152