### PR TITLE
Add ability to set podAnnotations

### DIFF
--- a/templates/analytics/analytics-deployment.yaml
+++ b/templates/analytics/analytics-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.analytics -}}
 {{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-analytics
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-analytics
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/cas/cas-deployment.yaml
+++ b/templates/cas/cas-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.cas -}}
 {{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-cas
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-cas
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/console/console-deployment.yaml
+++ b/templates/console/console-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.console -}}
 {{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-console
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-console
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/datadirsync/datadirsync-deployment.yaml
+++ b/templates/datadirsync/datadirsync-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.datadirsync  -}}
 {{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -16,6 +17,8 @@ spec:
     metadata:
       labels:
         app: {{ include "georchestra.fullname" . }}-datadirsync
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/datafeeder/datafeeder-deployment.yaml
+++ b/templates/datafeeder/datafeeder-deployment.yaml
@@ -2,6 +2,7 @@
 {{- if and $webapp.enabled .Values.georchestra.webapps.datafeeder_frontend.enabled -}}
 {{- $database := .Values.database -}}
 {{- $database_secret_datafeeder_name := printf "%s-database-datafeeder-secret" (include "georchestra.fullname" .) -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,6 +22,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-datafeeder
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-datafeeder
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/datafeeder/import-deployment.yaml
+++ b/templates/datafeeder/import-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.datafeeder_frontend -}}
 {{- if and .Values.georchestra.webapps.datafeeder.enabled $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-import
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-datafeeder-import
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/gateway/gateway-deployment.yaml
+++ b/templates/gateway/gateway-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.gateway -}}
 {{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-gateway
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gateway
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/geonetwork/elasticsearch/es-deployment.yaml
+++ b/templates/geonetwork/elasticsearch/es-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork.elasticsearch -}}
 {{- if and .Values.georchestra.webapps.geonetwork.enabled $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,6 +22,10 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-gn4-elasticsearch
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gn4-elasticsearch
+      {{- with $webapp.podAnnotations }}
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
+      {{- end }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/geonetwork/geonetwork-deployment.yaml
+++ b/templates/geonetwork/geonetwork-deployment.yaml
@@ -1,6 +1,7 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork -}}
 {{- if $webapp.enabled -}}
 {{- $database := .Values.database -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +23,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-geonetwork
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geonetwork
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/geonetwork/housekeeping/clean-harvester-logs.yaml
+++ b/templates/geonetwork/housekeeping/clean-harvester-logs.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork -}}
 {{- if and $webapp.enabled $webapp.housekeeping.harvester_logs.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.housekeeping.podAnnotations) }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -7,6 +8,8 @@ metadata:
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-housekeeping-clean-harvester-logs
+  annotations:
+    {{- toYaml $podAnnotations | nindent 4 }}
 spec:
   schedule: "{{ $webapp.housekeeping.harvester_logs.schedule }}"
   jobTemplate:
@@ -30,7 +33,7 @@ spec:
             - mountPath: /mnt/geonetwork_datadir
               name: geonetwork-datadir
             resources:
-              {{- toYaml $webapp.resources | nindent 14 }}
+              {{- toYaml $webapp.housekeeping.resources | nindent 14 }}
           volumes:
           - name: geonetwork-datadir
             persistentVolumeClaim:

--- a/templates/geonetwork/kibana/kibana-deployment.yaml
+++ b/templates/geonetwork/kibana/kibana-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork.kibana -}}
 {{- if and .Values.georchestra.webapps.geonetwork.enabled $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-gn4-kibana
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gn4-kibana
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/geonetwork/ogc-api-records/ogc-api-records-deployment.yaml
+++ b/templates/geonetwork/ogc-api-records/ogc-api-records-deployment.yaml
@@ -1,6 +1,7 @@
 {{- $webapp := .Values.georchestra.webapps.geonetwork.ogc_api_records -}}
 {{- if and .Values.georchestra.webapps.geonetwork.enabled $webapp.enabled -}}
 {{- $database := .Values.database -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -20,6 +21,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-gn4-ogc-api-records
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gn4-ogc-api-records
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -4,7 +4,7 @@
 {{- $database_secret_geodata_name := printf "%s-database-geodata-secret" (include "georchestra.fullname" .) -}}
 {{- $database_secret_datafeeder_name := printf "%s-database-datafeeder-secret" (include "georchestra.fullname" .) -}}
 {{- $database_secret_gwc_name := printf "%s-database-georchestra-secret" (include "georchestra.fullname" .) -}}
-
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -24,6 +24,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-geoserver
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geoserver
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/geowebcache/geowebcache-deployment.yaml
+++ b/templates/geowebcache/geowebcache-deployment.yaml
@@ -1,6 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.geowebcache -}}
 {{- if $webapp.enabled -}}
-
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +22,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-geowebcache
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geowebcache
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/header/header-deployment.yaml
+++ b/templates/header/header-deployment.yaml
@@ -1,5 +1,6 @@
-{{- if .Values.georchestra.webapps.header.enabled -}}
 {{- $webapp := .Values.georchestra.webapps.header -}}
+{{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-header
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-header
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/ldap/openldap-deployment.yaml
+++ b/templates/ldap/openldap-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.openldap -}}
 {{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,6 +22,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-ldap
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-ldap
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/mapstore/mapstore-deployment.yaml
+++ b/templates/mapstore/mapstore-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.mapstore -}}
 {{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -21,6 +22,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-mapstore
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-mapstore
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/security-proxy/security-proxy-deployment.yaml
+++ b/templates/security-proxy/security-proxy-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.webapps.proxy -}}
 {{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-sp
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-sp
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/templates/smtp-smarthost/smtp-deployment.yaml
+++ b/templates/smtp-smarthost/smtp-deployment.yaml
@@ -1,5 +1,6 @@
 {{- $webapp := .Values.georchestra.smtp_smarthost -}}
 {{- if $webapp.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $webapp.podAnnotations) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -19,6 +20,8 @@ spec:
         {{- include "georchestra.selectorLabels" . | nindent 8 }}
         org.georchestra.service/name: {{ include "georchestra.fullname" . }}-smtp
         app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-smtp
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
     spec:
       nodeSelector:
         "kubernetes.io/os": linux

--- a/values.yaml
+++ b/values.yaml
@@ -547,3 +547,7 @@ tooling:
     image:
       repository: georchestra/k8s-initcontainer-envsubst
       tag: latest
+
+# Annotations for all pods, can be merge/override for each webapp, and also smtp smarthost, datadirsync and rabbitmq
+# For builtin database use them under database.primary
+podAnnotations: {}


### PR DESCRIPTION
This PR add the ability to add annotations to deployed pods.

General annotation at the end of values.yaml will be added to all pods.

You also have ability to define podAnnotations for all pods, they are merged or they will override if same values as the general ones.

Also handle smtp smarthost, datadirsync and rabbitmq
For builtin database use them under database.primary