### PR TITLE
chore: move chown to a cronjob

### DIFF
--- a/templates/extra/cronjob-fix-permissions-pvc.yaml
+++ b/templates/extra/cronjob-fix-permissions-pvc.yaml
@@ -1,0 +1,63 @@
+{{- if and .Values.georchestra.webapps.geonetwork.enabled .Values.georchestra.webapps.geoserver.enabled -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict .Values.tooling.fixPermissionsPvc.podAnnotations ) }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "georchestra.fullname" . }}-fix-permissions-pvc
+  labels:
+    {{- include "georchestra.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-fix-permissions-pvc
+  annotations:
+    {{- toYaml $podAnnotations | nindent 4 }}
+spec:
+  schedule: "{{ .Values.tooling.fixPermissionsPvc.schedule }}"
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 86400
+      template:
+        spec:
+          containers:
+          - name: fix-permissions-pvc
+            image: "{{ .Values.tooling.general.image.repository }}:{{ .Values.tooling.general.image.tag }}"
+            imagePullPolicy: IfNotPresent
+            command:
+            - sh
+            - -c
+            - ionice
+            - -c2
+            - -n7
+            - chown
+            - -R
+            - 999:999
+            - /mnt/geoserver_datadir
+            - /mnt/geoserver_geodata
+            - /mnt/geoserver_tiles
+            - /mnt/geonetwork_datadir
+            volumeMounts:
+            - mountPath: /mnt/geonetwork_datadir
+              name: geonetwork-datadir
+            - mountPath: /mnt/geoserver_geodata
+              name: geoserver-geodata
+            - mountPath: /mnt/geoserver_datadir
+              name: geoserver-datadir
+            - mountPath: /mnt/geoserver_tiles
+              name: geoserver-tiles
+          volumes:
+          - name: geonetwork-datadir
+            persistentVolumeClaim:
+              claimName: {{ include "georchestra.fullname" . }}-geonetwork-datadir
+          - name: geoserver-tiles
+            persistentVolumeClaim:
+              claimName: {{ include "georchestra.fullname" . }}-geoserver-tiles
+          - name: geoserver-geodata
+            persistentVolumeClaim:
+              claimName: {{ include "georchestra.fullname" . }}-geoserver-geodata
+          - name: geoserver-datadir
+            persistentVolumeClaim:
+              claimName: {{ include "georchestra.fullname" . }}-geoserver-datadir
+          restartPolicy: OnFailure
+          {{- if .Values.tooling.fixPermissionsPvc.tolerations }}
+          tolerations:
+            {{- .Values.tooling.fixPermissionsPvc.tolerations | toYaml | nindent 12}}
+          {{- end }}
+{{- end }}

--- a/templates/geonetwork/elasticsearch/es-deployment.yaml
+++ b/templates/geonetwork/elasticsearch/es-deployment.yaml
@@ -32,13 +32,6 @@ spec:
         {{- end }}
       securityContext:
         fsGroup: 1000
-      initContainers:
-      - name: fix-permissions-pvc
-        image: "{{ .Values.tooling.general.image.repository }}:{{ .Values.tooling.general.image.tag }}"
-        command: ["sh", "-c", "chown -R 1000:1000 /usr/share/elasticsearch/data"]
-        volumeMounts:
-        - mountPath: /usr/share/elasticsearch/data
-          name: gn4-es-data
       containers:
       - name: elasticsearch
         image: {{ $webapp.image }}

--- a/templates/geonetwork/geonetwork-deployment.yaml
+++ b/templates/geonetwork/geonetwork-deployment.yaml
@@ -35,12 +35,6 @@ spec:
         fsGroup: 999
       initContainers:
       {{ include "georchestra.bootstrap_georchestra_datadir" $ | nindent 6 }}
-      - name: fix-permissions-pvc
-        image: "{{ .Values.tooling.general.image.repository }}:{{ .Values.tooling.general.image.tag }}"
-        command: ["sh", "-c", "chown -R 999:999 /mnt/geonetwork_datadir"]
-        volumeMounts:
-        - mountPath: /mnt/geonetwork_datadir
-          name: geonetwork-datadir
       containers:
       - name: georchestra-geonetwork
         image: {{ $webapp.docker_image }}

--- a/templates/geoserver/geoserver-deployment.yaml
+++ b/templates/geoserver/geoserver-deployment.yaml
@@ -36,14 +36,6 @@ spec:
         fsGroup: 999
       initContainers:
       {{ include "georchestra.bootstrap_georchestra_datadir" . | nindent 6 }}
-      - name: fix-permissions-pvc
-        image: "{{ .Values.tooling.general.image.repository }}:{{ .Values.tooling.general.image.tag }}"
-        command: ["sh", "-c", "chown -R 999:999 /mnt/geoserver_datadir /mnt/geoserver_geodata"]
-        volumeMounts:
-        - mountPath: /mnt/geoserver_datadir
-          name: geoserver-datadir
-        - mountPath: /mnt/geoserver_geodata
-          name: geoserver-geodata
       containers:
       - name: georchestra-geoserver
         image: {{ $webapp.docker_image }}

--- a/values.yaml
+++ b/values.yaml
@@ -547,6 +547,12 @@ tooling:
     image:
       repository: georchestra/k8s-initcontainer-envsubst
       tag: latest
+  # Fix the permissions for the PVCs at midnight
+  fixPermissionsPvc:
+    schedule: "0 0 * * *"
+    tolerations: []
+    podAnnotations: {}
+
 
 # Annotations for all pods, can be merge/override for each webapp, and also smtp smarthost, datadirsync and rabbitmq
 # For builtin database use them under database.primary


### PR DESCRIPTION
- Remove initcontainer chown for geoserver, geonetwork and elasticsearch
- Add a cronjob that chown with ionice (avoid overloading server) for geoserver and geonetwork by default at midnight (but configurable).

Reason: a chown takes ages on a volume for geoserver with 10TB in it, slowing down the startup of the app