### PR TITLE
chore: adapt SP healthcheck to only check root path

### DIFF
--- a/georchestra/Chart.yaml
+++ b/georchestra/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.11.2
+version: 1.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/georchestra/templates/security-proxy/security-proxy-deployment.yaml
+++ b/georchestra/templates/security-proxy/security-proxy-deployment.yaml
@@ -67,15 +67,19 @@ spec:
             name: georchestra-datadir
         livenessProbe:
           httpGet:
-            path: /_static/bootstrap_3.0.0/css/bootstrap-theme.min.css
+            path: /
             port: 8080
           periodSeconds: 10
-          timeoutSeconds: 3
-        startupProbe:
-          tcpSocket:
-            port: 8080
+          timeoutSeconds: 5
           failureThreshold: 5
-          periodSeconds: 15
+          successThreshold: 1
+        startupProbe:
+          httpGet:
+            path: /
+            port: 8080
+          periodSeconds: 10
+          failureThreshold: 10
+          timeoutSeconds: 3
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       volumes:


### PR DESCRIPTION
Move the healthcheck to only check the root path.

The previous healthcheck incurred a filesystem request, which take too much time to respond when the SP is almost overloaded. So Kubernetes was killing the SP due to a timeout.

The root path is in memory so it won't require a filesystem access.