### PR TITLE
chore: update to a better GS healthcheck

### DIFF
--- a/georchestra/templates/geoserver/geoserver-deployment.yaml
+++ b/georchestra/templates/geoserver/geoserver-deployment.yaml
@@ -194,10 +194,12 @@ spec:
           timeoutSeconds: 5
         {{- end }}
         startupProbe:
-          tcpSocket:
-            port: 8080
-          failureThreshold: 5
-          periodSeconds: 40
+          httpGet:
+            path: /geoserver/ows?SERVICE=WMS&REQUEST=DescribeLayer&LAYERS=geor:public_layer&VERSION=1.1.1
+            port: http
+            scheme: HTTP
+          failureThreshold: 60
+          periodSeconds: 5
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       volumes:


### PR DESCRIPTION
fixes #184

a getmap doesn't work great when control flow is enabled as it takes too much time to finish on a overloaded platform.

DescribeLayer however is pretty fast to finish