### PR TITLE
chore: move to native rabbitmq remove bitnami

### DIFF
--- a/georchestra/Chart.lock
+++ b/georchestra/Chart.lock
@@ -2,8 +2,5 @@ dependencies:
 - name: postgresql
   repository: oci://ghcr.io/georchestra/bitnami-helm-charts
   version: 15.5.2
-- name: rabbitmq
-  repository: oci://ghcr.io/georchestra/bitnami-helm-charts
-  version: 14.4.0
-digest: sha256:ccc78c2bf311b8d0fa8045bc0554e01ffaf52bd4bb9aaf7fefada5543055d464
-generated: "2025-09-01T11:05:34.650331473+02:00"
+digest: sha256:c1c8676aa13bdf112ecfd270e88aba5d80a8c034060ef7b0615d395bc56fe715
+generated: "2025-10-09T11:44:00.438950227+02:00"

--- a/georchestra/Chart.yaml
+++ b/georchestra/Chart.yaml
@@ -29,8 +29,3 @@ dependencies:
   repository: "oci://ghcr.io/georchestra/bitnami-helm-charts"
   condition: database.builtin
   alias: database
-- name: rabbitmq
-  version: 14.4.0
-  repository: "oci://ghcr.io/georchestra/bitnami-helm-charts"
-  condition: rabbitmq.enabled, rabbitmq.builtin
-  alias: rabbitmq

--- a/georchestra/templates/_helpers-rabbitmq.tpl
+++ b/georchestra/templates/_helpers-rabbitmq.tpl
@@ -4,12 +4,15 @@ Insert rabbitmq georchestra environment variables
 {{- define "georchestra.rabbitmq-georchestra-envs" -}}
 {{- $rabbitmq := .Values.rabbitmq -}}
 {{- $rabbitmq_secret_georchestra_name := "" -}}
-{{- if $rabbitmq.builtin }}
-{{- $rabbitmq_secret_georchestra_name = printf "%s-rabbitmq-georchestra-secret" (include "georchestra.fullname" .) -}}
-- name: RABBITMQ_HOST
-  value: "{{ .Release.Name }}-rabbitmq"
+{{- if $rabbitmq.auth.existingSecret }}
+{{- $rabbitmq_secret_georchestra_name = $rabbitmq.auth.existingSecret -}}
 {{- else }}
-{{- $rabbitmq_secret_georchestra_name = .Values.rabbitmq.auth.existingSecret -}}
+{{- $rabbitmq_secret_georchestra_name = printf "%s-rabbitmq-georchestra-secret" (include "georchestra.fullname" .) -}}
+{{- end }}
+{{- if not $rabbitmq.auth.host }}
+- name: RABBITMQ_HOST
+  value: "{{ include "georchestra.fullname" . }}-rabbitmq"
+{{- else }}
 - name: RABBITMQ_HOST
   valueFrom:
     secretKeyRef:

--- a/georchestra/templates/rabbitmq/rabbitmq-deployment.yaml
+++ b/georchestra/templates/rabbitmq/rabbitmq-deployment.yaml
@@ -1,0 +1,95 @@
+{{- $rabbitmq := .Values.rabbitmq -}}
+{{- if and $rabbitmq.enabled (not $rabbitmq.auth.host) -}}
+{{- $podAnnotations := mergeOverwrite .Values.podAnnotations (default dict $rabbitmq.podAnnotations) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "georchestra.fullname" . }}-rabbitmq
+  labels:
+    {{- include "georchestra.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-rabbitmq
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "georchestra.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-rabbitmq
+  template:
+    metadata:
+      labels:
+        {{- include "georchestra.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-rabbitmq
+      annotations:
+        {{- toYaml $podAnnotations | nindent 8 }}
+    spec:
+      nodeSelector:
+        "kubernetes.io/os": linux
+        {{- with .Values.georchestra.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      containers:
+      - name: rabbitmq
+        image: "{{ $rabbitmq.image.repository }}:{{ $rabbitmq.image.tag }}"
+        imagePullPolicy: {{ $rabbitmq.image.pullPolicy }}
+        env:
+        - name: RABBITMQ_DEFAULT_USER
+          value: {{ $rabbitmq.auth.username | quote }}
+        - name: RABBITMQ_DEFAULT_PASS
+          value: {{ $rabbitmq.auth.password | quote }}
+        - name: RABBITMQ_ERLANG_COOKIE
+          value: {{ $rabbitmq.auth.erlangCookie | quote }}
+        {{- if $rabbitmq.extra_environment }}
+        {{- $rabbitmq.extra_environment | toYaml | nindent 8 }}
+        {{- end }}
+        ports:
+        - name: amqp
+          containerPort: 5672
+          protocol: TCP
+        - name: management
+          containerPort: 15672
+          protocol: TCP
+        - name: epmd
+          containerPort: 4369
+          protocol: TCP
+        volumeMounts:
+        - name: rabbitmq-data
+          mountPath: /var/lib/rabbitmq
+        livenessProbe:
+          exec:
+            command:
+            - rabbitmq-diagnostics
+            - -q
+            - ping
+          initialDelaySeconds: 120
+          periodSeconds: 30
+          timeoutSeconds: 20
+          failureThreshold: 6
+        readinessProbe:
+          exec:
+            command:
+            - rabbitmq-diagnostics
+            - -q
+            - check_running
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 20
+          failureThreshold: 3
+        resources:
+          {{- toYaml $rabbitmq.resources | nindent 10 }}
+      volumes:
+      - name: rabbitmq-data
+        persistentVolumeClaim:
+          claimName: {{ include "georchestra.fullname" . }}-rabbitmq
+      {{- if $rabbitmq.registry_secret }}
+      imagePullSecrets:
+      - name: {{ $rabbitmq.registry_secret }}
+      {{- end }}
+      {{- if $rabbitmq.tolerations }}
+      tolerations:
+        {{- $rabbitmq.tolerations | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if .Values.hostAliases }}
+      hostAliases:
+        {{- .Values.hostAliases | toYaml | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/georchestra/templates/rabbitmq/rabbitmq-pvc.yaml
+++ b/georchestra/templates/rabbitmq/rabbitmq-pvc.yaml
@@ -1,6 +1,6 @@
 {{- $rabbitmq := .Values.rabbitmq -}}
 {{- $rabbitmq_storage := .Values.rabbitmq.storage -}}
-{{- if and $rabbitmq.enabled $rabbitmq.storage -}}
+{{- if and $rabbitmq.enabled (not $rabbitmq.auth.host) -}}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -14,6 +14,8 @@ spec:
   {{- range $rabbitmq_storage.accessModes }}
   - {{ . | quote }}
   {{- end }}
+  {{- else }}
+  - "ReadWriteOnce"
   {{- end }}
   {{- if (eq "-" $rabbitmq_storage.storage_class_name) }}
   storageClassName: ""

--- a/georchestra/templates/rabbitmq/rabbitmq-secret.yaml
+++ b/georchestra/templates/rabbitmq/rabbitmq-secret.yaml
@@ -9,8 +9,8 @@ metadata:
     {{- include "georchestra.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- if $rabbitmq.builtin }}
-  host: {{ printf "%s-rabbitmq" .Release.Name | b64enc | quote  }}
+  {{- if not $rabbitmq.auth.host }}
+  host: {{ printf "%s-rabbitmq" (include "georchestra.fullname" .) | b64enc | quote  }}
   {{- else }}
   host: {{ $rabbitmq.auth.host | b64enc | quote }}
   {{- end }}

--- a/georchestra/templates/rabbitmq/rabbitmq-svc.yaml
+++ b/georchestra/templates/rabbitmq/rabbitmq-svc.yaml
@@ -1,0 +1,28 @@
+{{- $rabbitmq := .Values.rabbitmq -}}
+{{- if and $rabbitmq.enabled (not $rabbitmq.auth.host) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "georchestra.fullname" . }}-rabbitmq
+  labels:
+    {{- include "georchestra.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-rabbitmq
+spec:
+  type: ClusterIP
+  ports:
+  - name: amqp
+    port: 5672
+    targetPort: amqp
+    protocol: TCP
+  - name: management
+    port: 15672
+    targetPort: management
+    protocol: TCP
+  - name: epmd
+    port: 4369
+    targetPort: epmd
+    protocol: TCP
+  selector:
+    {{- include "georchestra.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-rabbitmq
+{{- end }}

--- a/georchestra/values.yaml
+++ b/georchestra/values.yaml
@@ -505,20 +505,35 @@ database:
 
 rabbitmq:
   enabled: false
-  builtin: true
+  image:
+    repository: rabbitmq
+    tag: 3.13-alpine
+    pullPolicy: IfNotPresent
   auth:
     username: georchestra
     password: georchestra
-    erlangCookie: georchestra  # needed only for builtin rabbitmq
-#   host: rabbitmq
+    erlangCookie: georchestra
+#   host: rabbitmq  # for external rabbitmq - if set, builtin rabbitmq deployment is disabled
     port: "5672"
 #   existingSecret: mysecret
-  # if you want to attach any existing PV - don't use this parameter
-  # if you just automatically want storage, consult the bitnam helm chart doc
-#  storage:
-#    pv_name: rabbitmq-data
-#    storage_class_name: default
-#    size: 1Gi
+  extra_environment: []
+  tolerations: []
+  podAnnotations: {}
+  # registry_secret: default
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+    limits:
+      memory: 256Mi
+  # Storage configuration - always creates a PVC
+  # Specify pv_name to bind to an existing PV, otherwise dynamically provisions
+  storage:
+    # pv_name: rabbitmq-data  # Optional: name of existing PV to bind to
+    # storage_class_name: default  # Optional: storage class name
+    accessModes:
+    - ReadWriteOnce
+    size: 1Gi
 
 # Allow to override /etc/hosts for ALL apps
 # https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/


### PR DESCRIPTION
Related to https://github.com/georchestra/helm-charts/pull/178

Remove bitnami helm chart and remove usage of bitnami docker image.

Instead use official rabbitmq docker image: https://hub.docker.com/_/rabbitmq