### PR TITLE
Gaia improvement

### DIFF
--- a/gaia/Chart.yaml
+++ b/gaia/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.3
+version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/gaia/helmfile.yaml
+++ b/gaia/helmfile.yaml
@@ -1,6 +1,0 @@
-releases:
-  - name: gaia
-    chart: ./
-    version: 0.1.0
-    values:
-      - values.yaml

--- a/gaia/templates/_bootstrap-gaia-configuration.tpl
+++ b/gaia/templates/_bootstrap-gaia-configuration.tpl
@@ -4,14 +4,14 @@
   command:
   - /bin/sh
   - -c
-  - {{- if .Values.datadir.git.ssh_secret }}
+  - {{- if .Values.datadir.git.sshSecret }}
     mkdir -p /root/.ssh ;
     cp /ssh-secret/ssh-privatekey /root/.ssh/id_rsa ;
     chmod 0600 /root/.ssh/id_rsa ;
     {{- end }}
     rm -Rf /etc/georchestra ;
     git clone --depth 1 --single-branch {{ .Values.datadir.git.url }} -b {{ .Values.datadir.git.ref }} /etc/georchestra ;
-  {{- if .Values.datadir.git.ssh_secret }}
+  {{- if .Values.datadir.git.sshSecret }}
   env:
     - name: GIT_SSH_COMMAND
       value: ssh -o "IdentitiesOnly=yes" -o "StrictHostKeyChecking no"
@@ -19,7 +19,7 @@
   volumeMounts:
   - mountPath: /etc/georchestra
     name: georchestra-datadir
-  {{- if .Values.datadir.git.ssh_secret }}
+  {{- if .Values.datadir.git.sshSecret }}
   - mountPath: /ssh-secret
     name: ssh-secret
   {{- end }}

--- a/gaia/templates/_helpers.tpl
+++ b/gaia/templates/_helpers.tpl
@@ -35,6 +35,7 @@ Common labels
 */}}
 {{- define "helm-gaia.labels" -}}
 helm.sh/chart: {{ include "helm-gaia.chart" . }}
+{{ include "helm-gaia.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
@@ -44,17 +45,18 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "helm-gaia.selectorLabelsCelery" -}}
-app.kubernetes.io/name: {{ .Release.Name }}
-app.kubernetes.io/instance: {{ include "helm-gaia.name" . }}-gaia-celery
+{{- define "helm-gaia.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "helm-gaia.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
-{{- define "helm-gaia.selectorLabelsBack" -}}
-app.kubernetes.io/name: {{ .Release.Name }}
-app.kubernetes.io/instance: {{ include "helm-gaia.name" . }}-gaia
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "helm-gaia.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "helm-gaia.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
 {{- end }}
-
-{{- define "helm-gaia.selectorLabelsRedis" -}}
-app.kubernetes.io/name: {{ .Release.Name }}
-app.kubernetes.io/instance: {{ include "helm-gaia.name" . }}-gaia-redis
 {{- end }}

--- a/gaia/templates/_helpers.tpl
+++ b/gaia/templates/_helpers.tpl
@@ -44,11 +44,6 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Selector labels
 */}}
-{{- define "helm-gaia.selectorLabels" -}}
-app.kubernetes.io/name: {{ .Release.Name }}
-app.kubernetes.io/instance: {{ include "helm-gaia.name" . }}
-{{- end }}
-
 {{- define "helm-gaia.selectorLabelsCelery" -}}
 app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ include "helm-gaia.name" . }}-gaia-celery
@@ -62,15 +57,4 @@ app.kubernetes.io/instance: {{ include "helm-gaia.name" . }}-gaia
 {{- define "helm-gaia.selectorLabelsRedis" -}}
 app.kubernetes.io/name: {{ .Release.Name }}
 app.kubernetes.io/instance: {{ include "helm-gaia.name" . }}-gaia-redis
-{{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "helm-gaia.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "helm-gaia.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
 {{- end }}

--- a/gaia/templates/gaia-celery-deployment.yaml
+++ b/gaia/templates/gaia-celery-deployment.yaml
@@ -4,13 +4,14 @@ kind: Deployment
 metadata:
   name: {{ include "helm-gaia.fullname" . }}-gaia-celery-deployment
   labels:
-    {{- include "helm-gaia.selectorLabelsCelery" . | nindent 4 }}
     {{- include "helm-gaia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-celery
 spec:
   replicas: {{ .Values.gaiaCelery.replicaCount }}
   selector:
     matchLabels:
-      {{- include "helm-gaia.selectorLabelsCelery" . | nindent 6 }}
+      {{- include "helm-gaia.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-celery
   template:
     metadata:
       {{- with .Values.gaiaCelery.podAnnotations }}
@@ -18,7 +19,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "helm-gaia.selectorLabelsCelery" . | nindent 8 }}
+        {{- include "helm-gaia.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-celery
     spec:
       initContainers:
       {{- if .Values.datadir.git.url }}

--- a/gaia/templates/gaia-celery-deployment.yaml
+++ b/gaia/templates/gaia-celery-deployment.yaml
@@ -45,17 +45,11 @@ spec:
             {{- toYaml .Values.gaiaCelery.securityContext | nindent 12 }}
           image: "{{ .Values.gaiaCelery.image.repository }}:{{ .Values.gaiaCelery.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.gaiaCelery.image.pullPolicy }}
-          ports:
-            - name: http
-              containerPort: 5002
-              protocol: TCP
           resources:
             {{- toYaml .Values.gaiaCelery.resources | nindent 12 }}
           env:
             - name: FLASK_APP
               value: geordash
-            - name:  FLASK_OPTS
-              value: "-h 0.0.0.0 -p 5002"
             - name: REDISURL
               value: "redis://{{ include "helm-gaia.fullname" . }}-gaia-redis-svc:{{ .Values.redis.service.port }}/1"
             {{- include "gaia.bootstrap_gaia_database_envs" . | nindent 12 }}

--- a/gaia/templates/gaia-celery-deployment.yaml
+++ b/gaia/templates/gaia-celery-deployment.yaml
@@ -115,7 +115,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.gaiaCelery.image.imagePullSecrets }}
-      imagePullSecrets:
-        - name: {{ .Values.gaiaCelery.image.imagePullSecrets }}
-      {{- end }}

--- a/gaia/templates/gaia-celery-deployment.yaml
+++ b/gaia/templates/gaia-celery-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gaiaCelery.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -115,3 +116,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/gaia/templates/gaia-celery-deployment.yaml
+++ b/gaia/templates/gaia-celery-deployment.yaml
@@ -6,13 +6,13 @@ metadata:
     {{- include "helm-gaia.selectorLabelsCelery" . | nindent 4 }}
     {{- include "helm-gaia.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.gaia_celery.replicaCount }}
+  replicas: {{ .Values.gaiaCelery.replicaCount }}
   selector:
     matchLabels:
       {{- include "helm-gaia.selectorLabelsCelery" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.gaia_celery.podAnnotations }}
+      {{- with .Values.gaiaCelery.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -32,24 +32,24 @@ spec:
         volumeMounts:
           - mountPath: /geordash/workdir/
             name: gaia-celery-scheduler
-      {{- with .Values.gaia_celery.imagePullSecrets }}
+      {{- with .Values.gaiaCelery.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       securityContext:
-        {{- toYaml .Values.gaia_celery.podSecurityContext | nindent 8 }}
+        {{- toYaml .Values.gaiaCelery.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}-celery
           securityContext:
-            {{- toYaml .Values.gaia_celery.securityContext | nindent 12 }}
-          image: "{{ .Values.gaia_celery.image.repository }}:{{ .Values.gaia_celery.image.tag | default .Chart.AppVersion }}"
-          imagePullPolicy: {{ .Values.gaia_celery.image.pullPolicy }}
+            {{- toYaml .Values.gaiaCelery.securityContext | nindent 12 }}
+          image: "{{ .Values.gaiaCelery.image.repository }}:{{ .Values.gaiaCelery.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.gaiaCelery.image.pullPolicy }}
           ports:
             - name: http
               containerPort: 5002
               protocol: TCP
           resources:
-            {{- toYaml .Values.gaia_celery.resources | nindent 12 }}
+            {{- toYaml .Values.gaiaCelery.resources | nindent 12 }}
           env:
             - name: FLASK_APP
               value: geordash
@@ -59,7 +59,7 @@ spec:
               value: "redis://{{ include "helm-gaia.fullname" . }}-gaia-redis-svc:{{ .Values.redis.service.port }}/1"
             {{- include "gaia.bootstrap_gaia_database_envs" . | nindent 12 }}
             {{- include "gaia.service-envs" . | nindent 12 }}
-          {{- with .Values.gaia_celery.extra_environment }}
+          {{- with .Values.gaiaCelery.extraEnvironment }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
@@ -97,25 +97,25 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.volumes.mapstoreDatadir.name }}
 
-        {{- if .Values.datadir.git.ssh_secret }}
+        {{- if .Values.datadir.git.sshSecret }}
         - name: ssh-secret
           secret:
-            secretName: {{ .Values.datadir.git.ssh_secret }}
+            secretName: {{ .Values.datadir.git.sshSecret }}
             defaultMode: 0400
         {{- end }}
-      {{- with .Values.gaia_celery.nodeSelector }}
+      {{- with .Values.gaiaCelery.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.gaia_celery.affinity }}
+      {{- with .Values.gaiaCelery.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.gaia_celery.tolerations }}
+      {{- with .Values.gaiaCelery.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.gaia_celery.image.imagePullSecrets }}
+      {{- if .Values.gaiaCelery.image.imagePullSecrets }}
       imagePullSecrets:
-        - name: {{ .Values.gaia_celery.image.imagePullSecrets }}
+        - name: {{ .Values.gaiaCelery.image.imagePullSecrets }}
       {{- end }}

--- a/gaia/templates/gaia-celery-deployment.yaml
+++ b/gaia/templates/gaia-celery-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name:  FLASK_OPTS
               value: "-h 0.0.0.0 -p 5002"
             - name: REDISURL
-              value: "redis://{{ include "helm-gaia.fullname" . }}-gaia-redis-svc:6379/1"
+              value: "redis://{{ include "helm-gaia.fullname" . }}-gaia-redis-svc:{{ .Values.redis.service.port }}/1"
             {{- include "gaia.bootstrap_gaia_database_envs" . | nindent 12 }}
             {{- include "gaia.service-envs" . | nindent 12 }}
           {{- with .Values.gaia_celery.extra_environment }}

--- a/gaia/templates/gaia-celery-svc.yaml
+++ b/gaia/templates/gaia-celery-svc.yaml
@@ -16,5 +16,6 @@ spec:
       targetPort: http
       protocol: TCP
   selector:
-    {{- include "helm-gaia.selectorLabelsCelery" . | nindent 4 }}
+    {{- include "helm-gaia.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-celery
 {{- end }}

--- a/gaia/templates/gaia-celery-svc.yaml
+++ b/gaia/templates/gaia-celery-svc.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.gaia_celery.service.type }}
   ports:
     - port: {{ .Values.gaia_celery.service.port }}
-      targetPort: {{ .Values.gaia_celery.service.port }}
+      targetPort: http
       protocol: TCP
   selector:
     app.kubernetes.io/name: {{ include "helm-gaia.fullname" . }}

--- a/gaia/templates/gaia-celery-svc.yaml
+++ b/gaia/templates/gaia-celery-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gaiaCelery.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
       protocol: TCP
   selector:
     {{- include "helm-gaia.selectorLabelsCelery" . | nindent 4 }}
+{{- end }}

--- a/gaia/templates/gaia-celery-svc.yaml
+++ b/gaia/templates/gaia-celery-svc.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "helm-gaia.fullname" . }}-gaia-celery-svc
   labels:
     {{- include "helm-gaia.labels" . | nindent 4 }}
+  {{- with .Values.gaiaCelery.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.gaiaCelery.service.type }}
   ports:

--- a/gaia/templates/gaia-celery-svc.yaml
+++ b/gaia/templates/gaia-celery-svc.yaml
@@ -11,5 +11,4 @@ spec:
       targetPort: http
       protocol: TCP
   selector:
-    app.kubernetes.io/name: {{ include "helm-gaia.fullname" . }}
-    app.kubernetes.io/instance: {{ include "helm-gaia.fullname" . }}-gaia-celery
+    {{- include "helm-gaia.selectorLabelsCelery" . | nindent 4 }}

--- a/gaia/templates/gaia-celery-svc.yaml
+++ b/gaia/templates/gaia-celery-svc.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     {{- include "helm-gaia.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.gaia_celery.service.type }}
+  type: {{ .Values.gaiaCelery.service.type }}
   ports:
-    - port: {{ .Values.gaia_celery.service.port }}
+    - port: {{ .Values.gaiaCelery.service.port }}
       targetPort: http
       protocol: TCP
   selector:

--- a/gaia/templates/gaia-deployment.yaml
+++ b/gaia/templates/gaia-deployment.yaml
@@ -111,7 +111,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.gaia.image.imagePullSecrets }}
-      imagePullSecrets:
-        - name: {{ .Values.gaia.image.imagePullSecrets }}
-      {{- end }}

--- a/gaia/templates/gaia-deployment.yaml
+++ b/gaia/templates/gaia-deployment.yaml
@@ -59,7 +59,7 @@ spec:
               value: "redis://{{ include "helm-gaia.fullname" . }}-gaia-redis-svc:{{ .Values.redis.service.port }}/1"
             {{- include "gaia.bootstrap_gaia_database_envs" . | nindent 12 }}
             {{- include "gaia.service-envs" . | nindent 12 }}
-          {{- with .Values.gaia.extra_environment }}
+          {{- with .Values.gaia.extraEnvironment }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
@@ -93,10 +93,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Values.volumes.mapstoreDatadir.name }}
 
-        {{- if .Values.datadir.git.ssh_secret }}
+        {{- if .Values.datadir.git.sshSecret }}
         - name: ssh-secret
           secret:
-            secretName: {{ .Values.datadir.git.ssh_secret }}
+            secretName: {{ .Values.datadir.git.sshSecret }}
             defaultMode: 0400
         {{- end }}
       {{- with .Values.gaia.nodeSelector }}

--- a/gaia/templates/gaia-deployment.yaml
+++ b/gaia/templates/gaia-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gaia.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -111,3 +112,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/gaia/templates/gaia-deployment.yaml
+++ b/gaia/templates/gaia-deployment.yaml
@@ -40,14 +40,10 @@ spec:
               containerPort: 5002
               protocol: TCP
           livenessProbe:
-          {{- if .Values.gaia.custom_liveness_probe -}}
-          {{ .Values.gaia.custom_liveness_probe | toYaml | nindent 12 }}
-          {{- else }}
             httpGet:
               path: /gaia/
               port: 5002
             initialDelaySeconds: 45
-          {{- end }}
           readinessProbe:
             httpGet:
               path: /gaia/

--- a/gaia/templates/gaia-deployment.yaml
+++ b/gaia/templates/gaia-deployment.yaml
@@ -4,13 +4,14 @@ kind: Deployment
 metadata:
   name: {{ include "helm-gaia.fullname" . }}-gaia-deployment
   labels:
-    {{- include "helm-gaia.selectorLabelsBack" . | nindent 4 }}
     {{- include "helm-gaia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-back
 spec:
   replicas: {{ .Values.gaia.replicaCount }}
   selector:
     matchLabels:
-      {{- include "helm-gaia.selectorLabelsBack" . | nindent 6 }}
+      {{- include "helm-gaia.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-back
   template:
     metadata:
       {{- with .Values.gaia.podAnnotations }}
@@ -18,7 +19,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "helm-gaia.selectorLabelsBack" . | nindent 8 }}
+        {{- include "helm-gaia.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-back
     spec:
       {{- if .Values.datadir.git.url }}
       initContainers:

--- a/gaia/templates/gaia-deployment.yaml
+++ b/gaia/templates/gaia-deployment.yaml
@@ -42,12 +42,12 @@ spec:
           livenessProbe:
             httpGet:
               path: /gaia/
-              port: 5002
+              port: http
             initialDelaySeconds: 45
           readinessProbe:
             httpGet:
               path: /gaia/
-              port: 5002
+              port: http
           resources:
             {{- toYaml .Values.gaia.resources | nindent 12 }}
           env:
@@ -56,7 +56,7 @@ spec:
             - name:  FLASK_OPTS
               value: "-h 0.0.0.0 -p 5002"
             - name: REDISURL
-              value: "redis://{{ include "helm-gaia.fullname" . }}-gaia-redis-svc:6379/1"
+              value: "redis://{{ include "helm-gaia.fullname" . }}-gaia-redis-svc:{{ .Values.redis.service.port }}/1"
             {{- include "gaia.bootstrap_gaia_database_envs" . | nindent 12 }}
             {{- include "gaia.service-envs" . | nindent 12 }}
           {{- with .Values.gaia.extra_environment }}

--- a/gaia/templates/gaia-svc.yaml
+++ b/gaia/templates/gaia-svc.yaml
@@ -16,5 +16,6 @@ spec:
       targetPort: http
       protocol: TCP
   selector:
-    {{- include "helm-gaia.selectorLabelsBack" . | nindent 4 }}
+    {{- include "helm-gaia.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-back
 {{- end }}

--- a/gaia/templates/gaia-svc.yaml
+++ b/gaia/templates/gaia-svc.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "helm-gaia.fullname" . }}-gaia-svc
   labels:
     {{- include "helm-gaia.labels" . | nindent 4 }}
+  {{- with .Values.gaia.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.gaia.service.type }}
   ports:

--- a/gaia/templates/gaia-svc.yaml
+++ b/gaia/templates/gaia-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gaia.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
       protocol: TCP
   selector:
     {{- include "helm-gaia.selectorLabelsBack" . | nindent 4 }}
+{{- end }}

--- a/gaia/templates/gaia-svc.yaml
+++ b/gaia/templates/gaia-svc.yaml
@@ -8,7 +8,7 @@ spec:
   type: {{ .Values.gaia.service.type }}
   ports:
     - port: {{ .Values.gaia.service.port }}
-      targetPort: {{ .Values.gaia.service.port }}
+      targetPort: http
       protocol: TCP
   selector:
     app.kubernetes.io/name: {{ include "helm-gaia.fullname" . }}

--- a/gaia/templates/gaia-svc.yaml
+++ b/gaia/templates/gaia-svc.yaml
@@ -11,5 +11,4 @@ spec:
       targetPort: http
       protocol: TCP
   selector:
-    app.kubernetes.io/name: {{ include "helm-gaia.fullname" . }}
-    app.kubernetes.io/instance: {{ include "helm-gaia.fullname" . }}-gaia
+    {{- include "helm-gaia.selectorLabelsBack" . | nindent 4 }}

--- a/gaia/templates/redis-deployment.yaml
+++ b/gaia/templates/redis-deployment.yaml
@@ -78,7 +78,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.redis.image.imagePullSecrets }}
-      imagePullSecrets:
-        - name: {{ .Values.redis.image.imagePullSecrets }}
-      {{- end }}

--- a/gaia/templates/redis-deployment.yaml
+++ b/gaia/templates/redis-deployment.yaml
@@ -4,13 +4,14 @@ kind: Deployment
 metadata:
   name: {{ include "helm-gaia.fullname" . }}-gaia-redis-deployment
   labels:
-    {{- include "helm-gaia.selectorLabelsRedis" . | nindent 4 }}
     {{- include "helm-gaia.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-redis
 spec:
   replicas: {{ .Values.redis.replicaCount }}
   selector:
     matchLabels:
-      {{- include "helm-gaia.selectorLabelsRedis" . | nindent 6 }}
+      {{- include "helm-gaia.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-redis
   template:
     metadata:
       {{- with .Values.redis.podAnnotations }}
@@ -18,7 +19,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
-        {{- include "helm-gaia.selectorLabelsRedis" . | nindent 8 }}
+        {{- include "helm-gaia.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-redis
     spec:
       {{- with .Values.redis.imagePullSecrets }}
       imagePullSecrets:

--- a/gaia/templates/redis-deployment.yaml
+++ b/gaia/templates/redis-deployment.yaml
@@ -36,9 +36,6 @@ spec:
               containerPort: 6379
               protocol: TCP
           livenessProbe:
-          {{- if .Values.redis.custom_liveness_probe -}}
-          {{ .Values.redis.custom_liveness_probe | toYaml | nindent 12 }}
-          {{- else }}
             tcpSocket:
               port: redis
             initialDelaySeconds: 30
@@ -46,7 +43,6 @@ spec:
             periodSeconds: 5
             failureThreshold: 5
             successThreshold: 1
-          {{- end }}
           readinessProbe:
             exec:
               command:

--- a/gaia/templates/redis-deployment.yaml
+++ b/gaia/templates/redis-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: {{ .Chart.Name }}-redis
           securityContext:
             {{- toYaml .Values.redis.securityContext | nindent 12 }}
-          image: "{{ .Values.redis.image.repository }}"
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
           ports:
             - name: redis

--- a/gaia/templates/redis-deployment.yaml
+++ b/gaia/templates/redis-deployment.yaml
@@ -56,7 +56,7 @@ spec:
           env:
             - name: REDIS_REPLICATION_MODE
               value: master
-          {{- with .Values.redis.extra_environment }}
+          {{- with .Values.redis.extraEnvironment }}
             {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:

--- a/gaia/templates/redis-deployment.yaml
+++ b/gaia/templates/redis-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -78,3 +79,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/gaia/templates/redis-pvc-data.yaml
+++ b/gaia/templates/redis-pvc-data.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -32,3 +33,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.redis.redisData.size }}
+{{- end }}

--- a/gaia/templates/redis-pvc-data.yaml
+++ b/gaia/templates/redis-pvc-data.yaml
@@ -9,23 +9,15 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  {{- if.Values.redis.redisData.accessModes }}
   {{- range .Values.redis.redisData.accessModes }}
   - {{ . | quote }}
   {{- end }}
-  {{- else }}
-  {{- range .Values.redis.redisData.accessModes }}
-  - {{ . | quote }}
-  {{- end }}
-  {{- end }}
+  {{- if .Values.redis.redisData.storageClassName }}
   {{- if (eq "-" .Values.redis.redisData.storageClassName) }}
   storageClassName: ""
-  {{- else if .Values.redis.redisData.storageClassName }}
+  {{- else }}
   storageClassName: {{ .Values.redis.redisData.storageClassName }}
-  {{- else if (eq "-" .Values.redis.redisData.storageClassName) }}
-  storageClassName: ""
-  {{- else if .Values.redis.redisData.storageClassName }}
-  storageClassName: {{ .Values.redis.redisData.storageClassName }}
+  {{- end }}
   {{- end }}
   {{- if .Values.redis.redisData.pvName }}
   volumeName: {{ .Values.redis.redisData.pvName }}

--- a/gaia/templates/redis-pvc-data.yaml
+++ b/gaia/templates/redis-pvc-data.yaml
@@ -8,27 +8,27 @@ metadata:
     helm.sh/resource-policy: "keep"
 spec:
   accessModes:
-  {{- if.Values.redis.redis_data.accessModes }}
-  {{- range .Values.redis.redis_data.accessModes }}
+  {{- if.Values.redis.redisData.accessModes }}
+  {{- range .Values.redis.redisData.accessModes }}
   - {{ . | quote }}
   {{- end }}
   {{- else }}
-  {{- range .Values.redis.redis_data.accessModes }}
+  {{- range .Values.redis.redisData.accessModes }}
   - {{ . | quote }}
   {{- end }}
   {{- end }}
-  {{- if (eq "-" .Values.redis.redis_data.storage_class_name) }}
+  {{- if (eq "-" .Values.redis.redisData.storageClassName) }}
   storageClassName: ""
-  {{- else if .Values.redis.redis_data.storage_class_name }}
-  storageClassName: {{ .Values.redis.redis_data.storage_class_name }}
-  {{- else if (eq "-" .Values.redis.redis_data.storage_class_name) }}
+  {{- else if .Values.redis.redisData.storageClassName }}
+  storageClassName: {{ .Values.redis.redisData.storageClassName }}
+  {{- else if (eq "-" .Values.redis.redisData.storageClassName) }}
   storageClassName: ""
-  {{- else if .Values.redis.redis_data.storage_class_name }}
-  storageClassName: {{ .Values.redis.redis_data.storage_class_name }}
+  {{- else if .Values.redis.redisData.storageClassName }}
+  storageClassName: {{ .Values.redis.redisData.storageClassName }}
   {{- end }}
-  {{- if .Values.redis.redis_data.pv_name }}
-  volumeName: {{ .Values.redis.redis_data.pv_name }}
+  {{- if .Values.redis.redisData.pvName }}
+  volumeName: {{ .Values.redis.redisData.pvName }}
   {{- end }}
   resources:
     requests:
-      storage: {{ .Values.redis.redis_data.size }}
+      storage: {{ .Values.redis.redisData.size }}

--- a/gaia/templates/redis-svc.yaml
+++ b/gaia/templates/redis-svc.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "helm-gaia.fullname" . }}-gaia-redis-svc
   labels:
     {{- include "helm-gaia.labels" . | nindent 4 }}
+  {{- with .Values.redis.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.redis.service.type }}
   ports:

--- a/gaia/templates/redis-svc.yaml
+++ b/gaia/templates/redis-svc.yaml
@@ -5,10 +5,10 @@ metadata:
   labels:
     {{- include "helm-gaia.labels" . | nindent 4 }}
 spec:
-  type: {{ .Values.gaia.service.type }}
+  type: {{ .Values.redis.service.type }}
   ports:
     - port: {{ .Values.redis.service.port }}
-      targetPort: {{ .Values.redis.service.port }}
+      targetPort: redis
       protocol: TCP
   selector:
      app.kubernetes.io/name: {{ include "helm-gaia.fullname" . }}

--- a/gaia/templates/redis-svc.yaml
+++ b/gaia/templates/redis-svc.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,3 +13,4 @@ spec:
       protocol: TCP
   selector:
     {{- include "helm-gaia.selectorLabelsRedis" . | nindent 4 }}
+{{- end }}

--- a/gaia/templates/redis-svc.yaml
+++ b/gaia/templates/redis-svc.yaml
@@ -16,5 +16,6 @@ spec:
       targetPort: redis
       protocol: TCP
   selector:
-    {{- include "helm-gaia.selectorLabelsRedis" . | nindent 4 }}
+    {{- include "helm-gaia.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "helm-gaia.fullname" . }}-redis
 {{- end }}

--- a/gaia/templates/redis-svc.yaml
+++ b/gaia/templates/redis-svc.yaml
@@ -11,5 +11,4 @@ spec:
       targetPort: redis
       protocol: TCP
   selector:
-     app.kubernetes.io/name: {{ include "helm-gaia.fullname" . }}
-     app.kubernetes.io/instance: {{ include "helm-gaia.fullname" . }}-gaia-redis
+    {{- include "helm-gaia.selectorLabelsRedis" . | nindent 4 }}

--- a/gaia/values.yaml
+++ b/gaia/values.yaml
@@ -1,4 +1,4 @@
-gaia_celery:
+gaiaCelery:
   enabled: true
   replicaCount: 1
   image:
@@ -8,7 +8,7 @@ gaia_celery:
     pullPolicy: IfNotPresent
   tolerations: []
   affinity: {}
-  extra_environment: []
+  extraEnvironment: []
   service:
     type: ClusterIP
     port: 5002
@@ -30,14 +30,7 @@ gaia:
     pullPolicy: IfNotPresent
   tolerations: []
   affinity: {}
-  # A custom livenessProbe can be passed, as follows:
-  # custom_liveness_probe:
-  #   httpGet:
-  #     path: /health
-  #     port: http
-  #   initialDelaySeconds: 60
-  #   [...]
-  extra_environment: []
+  extraEnvironment: []
   service:
     type: ClusterIP
     port: 5002
@@ -58,14 +51,7 @@ redis:
     pullPolicy: IfNotPresent
   tolerations: []
   affinity: {}
-  # A custom livenessProbe can be passed, as follows:
-  # custom_liveness_probe:
-  #   httpGet:
-  #     path: /health
-  #     port: http
-  #   initialDelaySeconds: 60
-  #   [...]
-  extra_environment: []
+  extraEnvironment: []
   service:
     type: ClusterIP
     port: 6379
@@ -77,10 +63,10 @@ redis:
     requests:
       cpu: 100m
       memory: 128Mi
-  redis_data:
-    # pv_name: redis_data
+  redisData:
+    # pvName: redis_data
     size: 1Gi
-    # storage_class_name: default or "-" for empty storageClassName
+    # storageClassName: default or "-" for empty storageClassName
     accessModes:
     - ReadWriteOnce
 datadir:

--- a/gaia/values.yaml
+++ b/gaia/values.yaml
@@ -1,10 +1,10 @@
 gaiaCelery:
   enabled: true
   replicaCount: 1
+  imagePullSecrets: []
   image:
     repository: georchestra/gaia-celery
     tag: latest
-    imagePullSecrets: []
     pullPolicy: IfNotPresent
   tolerations: []
   affinity: {}
@@ -23,10 +23,10 @@ gaiaCelery:
 gaia:
   enabled: true
   replicaCount: 1
+  imagePullSecrets: []
   image:
     repository: georchestra/gaia
     tag: latest
-    imagePullSecrets: []
     pullPolicy: IfNotPresent
   tolerations: []
   affinity: {}
@@ -45,9 +45,9 @@ gaia:
 redis:
   enabled: true
   replicaCount: 1
+  imagePullSecrets: []
   image:
     repository: redis:8.2.2-alpine
-    imagePullSecrets: []
     pullPolicy: IfNotPresent
   tolerations: []
   affinity: {}

--- a/gaia/values.yaml
+++ b/gaia/values.yaml
@@ -23,13 +23,6 @@ gaia_celery:
 gaia:
   enabled: true
   replicaCount: 1
-  # A custom livenessProbe can be passed, as follows:
-  # custom_liveness_probe:
-  #   httpGet:
-  #     path: /health
-  #     port: http
-  #   initialDelaySeconds: 60
-  #   [...]
   image:
     repository: georchestra/gaia
     tag: latest
@@ -59,13 +52,6 @@ gaia:
 redis:
   enabled: true
   replicaCount: 1
-  # A custom livenessProbe can be passed, as follows:
-  # custom_liveness_probe:
-  #   httpGet:
-  #     path: /health
-  #     port: http
-  #   initialDelaySeconds: 60
-  #   [...]
   image:
     repository: redis:8.2.2-alpine
     imagePullSecrets: []

--- a/gaia/values.yaml
+++ b/gaia/values.yaml
@@ -71,9 +71,6 @@ redis:
     accessModes:
     - ReadWriteOnce
 datadir:
-  volume:
-  - name: georchestra-datadir
-    emptyDir: {}
   image:
     repository: bitnami/git
     tag: latest

--- a/gaia/values.yaml
+++ b/gaia/values.yaml
@@ -47,7 +47,8 @@ redis:
   replicaCount: 1
   imagePullSecrets: []
   image:
-    repository: redis:8.2.2-alpine
+    repository: redis
+    tag: 8.2.2-alpine
     pullPolicy: IfNotPresent
   tolerations: []
   affinity: {}


### PR DESCRIPTION
## Summary

This PR fixes three critical bugs that caused silent deployment failures, plus six structural issues and one quality improvement in the gaia Helm chart. It also includes three refactors (named ports, snake_case → camelCase, and standard Helm helpers) for complying with best practices given by [Helm](https://helm.sh/docs/chart_best_practices/) and [Kubernetes](https://kubernetes.io/blog/2025/11/25/configuration-good-practices/).

## Refactoring
**IMPORTANT**: Will need to adapt the values on the client side.

- **Use named ports** — Service targetPort and Deployment container ports now use named references (`http`, `redis`) instead of hardcoded numbers, making port changes a single-place edit.
- **Convert values keys from snake_case to camelCase** — values.yaml keys and template references aligned to camelCase, consistent with Helm best practices.
- **Adopt standard Helm `_helpers.tpl`** — Replaced the custom component-specific selector helpers (`selectorLabelsBack`, `selectorLabelsCelery`, `selectorLabelsRedis`) with the standard `helm-gaia.selectorLabels` helper, and added `helm-gaia.labels` including selector labels as per the standard Helm scaffold. Components are now distinguished by an `app.kubernetes.io/component` label (e.g. `<fullname>-back`, `<fullname>-celery`, `<fullname>-redis`) added alongside the shared selector labels in each Deployment and Service.

## Bug Fixes
### Service selectors did not match Deployment pod labels

Services used `helm-gaia.fullname` (release-qualified) in their selectors while Deployments labeled pods using `helm-gaia.name` (chart name only) via the `selectorLabels*` helpers.

This caused all three Services to route traffic to zero pods unless the Helm release happened to be named **exactly** `gaia`. All Service templates now use the same `selectorLabels*` helpers as their corresponding Deployments.

### imagePullSecrets was broken for all components

`imagePullSecrets` was declared nested under `image:` in values.yaml, but the standard pod-level `{{- with }}` block read from the component root — so it silently no-oped. A secondary `{{- if }}` block at the bottom of each Deployment template tried to work around this by treating the list as a plain string, producing invalid YAML.

Moved `imagePullSecrets` to the component root for `gaia`, `gaiaCelery`, and `redis`, and removed the broken duplicate blocks.

### enabled flags had no effect

`gaia.enabled`, `gaiaCelery.enabled`, and `redis.enabled` were declared in values.yaml but no template checked them — all three components were unconditionally rendered.

Added `{{- if .Values.<component>.enabled }}` guards to all Deployments, Services, and the Redis PVC.

## Structural Improvements

- **Redis image tag split from repository field** — `redis:8.2.2-alpine` was fused into the repository string, making it impossible to override just the tag via `--set`. Split into `repository: redis` + `tag: 8.2.2-alpine`, consistent with the other components.
- **service.annotations now rendered** — All three Service templates were missing the `{{- with .Values.<component>.service.annotations }}` block, silently dropping any user-supplied annotations (e.g. cloud load-balancer config, Prometheus scraping).
- **Dead code removed from `redis-pvc-data.yaml`** — The `accessModes` block rendered the same `range` loop in both `if` and `else` branches. The `storageClassName` block repeated identical conditions in unreachable `else if` branches. Both simplified to a single clean path.
- **Unused helpers and values removed** — `helm-gaia.selectorLabels` (never called), `helm-gaia.serviceAccountName` (referenced non-existent values keys, never called), and `datadir.volume` (never read by any template) were dead code.

## Quality

- **Celery Deployment no longer declares HTTP server config** — Removed the `ports` stanza (`5002/TCP`) and `FLASK_OPTS` env var from `gaia-celery-deployment.yaml`. Celery workers pull tasks from Redis and do not serve HTTP; these declarations were misleading noise copied from the gaia Deployment.
