### PR TITLE
Enable probes override

### DIFF
--- a/georchestra/templates/analytics/analytics-deployment.yaml
+++ b/georchestra/templates/analytics/analytics-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -57,11 +57,11 @@ spec:
             port: 8080
           periodSeconds: 10
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/analytics/analytics-deployment.yaml
+++ b/georchestra/templates/analytics/analytics-deployment.yaml
@@ -47,16 +47,30 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /analytics/
             port: 8080
           periodSeconds: 10
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           tcpSocket:
             port: 8080
           failureThreshold: 5
           periodSeconds: 10
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/cas/cas-deployment.yaml
+++ b/georchestra/templates/cas/cas-deployment.yaml
@@ -49,7 +49,7 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -59,11 +59,11 @@ spec:
             port: 8080
           periodSeconds: 10
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/cas/cas-deployment.yaml
+++ b/georchestra/templates/cas/cas-deployment.yaml
@@ -49,16 +49,30 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /cas/login
             port: 8080
           periodSeconds: 10
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           tcpSocket:
             port: 8080
           failureThreshold: 5
           periodSeconds: 60
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/console/console-deployment.yaml
+++ b/georchestra/templates/console/console-deployment.yaml
@@ -52,7 +52,7 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -63,11 +63,11 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/console/console-deployment.yaml
+++ b/georchestra/templates/console/console-deployment.yaml
@@ -52,17 +52,31 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /console/account/new
             port: 8080
           periodSeconds: 10
           timeoutSeconds: 3
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           tcpSocket:
             port: 8080
           failureThreshold: 5
           periodSeconds: 20
+        {{- end }}
         {{- with $webapp.lifecycle }}
         lifecycle:
           {{- toYaml . | nindent 10 }}

--- a/georchestra/templates/datafeeder/datafeeder-deployment.yaml
+++ b/georchestra/templates/datafeeder/datafeeder-deployment.yaml
@@ -111,11 +111,24 @@ spec:
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           tcpSocket:
             port: http-proxy
           periodSeconds: 10
           initialDelaySeconds: 20
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/datafeeder/datafeeder-deployment.yaml
+++ b/georchestra/templates/datafeeder/datafeeder-deployment.yaml
@@ -111,7 +111,7 @@ spec:
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -121,11 +121,11 @@ spec:
           periodSeconds: 10
           initialDelaySeconds: 20
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- end }}

--- a/georchestra/templates/datafeeder/import-deployment.yaml
+++ b/georchestra/templates/datafeeder/import-deployment.yaml
@@ -47,7 +47,7 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -58,11 +58,11 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/datafeeder/import-deployment.yaml
+++ b/georchestra/templates/datafeeder/import-deployment.yaml
@@ -47,17 +47,31 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /index.html
             port: 80
           periodSeconds: 10
           timeoutSeconds: 5
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           tcpSocket:
             port: 80
           failureThreshold: 5
           periodSeconds: 5
+        {{- end }}
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir

--- a/georchestra/templates/gateway/gateway-deployment.yaml
+++ b/georchestra/templates/gateway/gateway-deployment.yaml
@@ -55,17 +55,31 @@ spec:
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /actuator/health
             port: 8090
           periodSeconds: 10
           timeoutSeconds: 3
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           tcpSocket:
             port: 8080
           failureThreshold: 5
           periodSeconds: 15
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/gateway/gateway-deployment.yaml
+++ b/georchestra/templates/gateway/gateway-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -66,11 +66,11 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 3
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/geonetwork/elasticsearch/es-deployment.yaml
+++ b/georchestra/templates/geonetwork/elasticsearch/es-deployment.yaml
@@ -55,6 +55,10 @@ spec:
         ports:
         - containerPort: 9200
           name: elastic
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           exec:
             command:
@@ -66,6 +70,11 @@ spec:
           timeoutSeconds: 5
           failureThreshold: 3
           successThreshold: 1
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- else }}
         readinessProbe:
           exec:
             command:
@@ -79,6 +88,11 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 3
           successThreshold: 1
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - mountPath: /usr/share/elasticsearch/data
             name: gn4-es-data

--- a/georchestra/templates/geonetwork/elasticsearch/es-deployment.yaml
+++ b/georchestra/templates/geonetwork/elasticsearch/es-deployment.yaml
@@ -55,7 +55,7 @@ spec:
         ports:
         - containerPort: 9200
           name: elastic
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -71,7 +71,7 @@ spec:
           failureThreshold: 3
           successThreshold: 1
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -89,7 +89,7 @@ spec:
           failureThreshold: 3
           successThreshold: 1
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- end }}

--- a/georchestra/templates/geonetwork/geonetwork-deployment.yaml
+++ b/georchestra/templates/geonetwork/geonetwork-deployment.yaml
@@ -65,7 +65,7 @@ spec:
           {{- if $webapp.extra_environment }}
           {{- $webapp.extra_environment | toYaml | nindent 10 }}
           {{- end }}
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -76,11 +76,11 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/geonetwork/geonetwork-deployment.yaml
+++ b/georchestra/templates/geonetwork/geonetwork-deployment.yaml
@@ -65,17 +65,31 @@ spec:
           {{- if $webapp.extra_environment }}
           {{- $webapp.extra_environment | toYaml | nindent 10 }}
           {{- end }}
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /geonetwork/srv/eng/catalog.search
             port: 8080
           periodSeconds: 10
           timeoutSeconds: 5
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           tcpSocket:
             port: 8080
           failureThreshold: 5
           periodSeconds: 50
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/geonetwork/kibana/kibana-deployment.yaml
+++ b/georchestra/templates/geonetwork/kibana/kibana-deployment.yaml
@@ -44,7 +44,7 @@ spec:
         ports:
         - containerPort: 5601
           name: kibana
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -58,7 +58,7 @@ spec:
           timeoutSeconds: 5
           failureThreshold: 3
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -72,7 +72,7 @@ spec:
           timeoutSeconds: 3
           failureThreshold: 3
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- end }}

--- a/georchestra/templates/geonetwork/kibana/kibana-deployment.yaml
+++ b/georchestra/templates/geonetwork/kibana/kibana-deployment.yaml
@@ -44,6 +44,10 @@ spec:
         ports:
         - containerPort: 5601
           name: kibana
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /api/status
@@ -53,6 +57,11 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
           failureThreshold: 3
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- else }}
         readinessProbe:
           httpGet:
             path: /api/status
@@ -62,6 +71,11 @@ spec:
           periodSeconds: 5
           timeoutSeconds: 3
           failureThreshold: 3
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - mountPath: /usr/share/kibana/config
             name: gn4-kibana-config

--- a/georchestra/templates/geonetwork/ogc-api-records/ogc-api-records-deployment.yaml
+++ b/georchestra/templates/geonetwork/ogc-api-records/ogc-api-records-deployment.yaml
@@ -80,15 +80,15 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- end }}

--- a/georchestra/templates/geonetwork/ogc-api-records/ogc-api-records-deployment.yaml
+++ b/georchestra/templates/geonetwork/ogc-api-records/ogc-api-records-deployment.yaml
@@ -80,6 +80,18 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
         - mountPath: /etc/georchestra
           name: georchestra-datadir

--- a/georchestra/templates/geoserver/geoserver-deployment.yaml
+++ b/georchestra/templates/geoserver/geoserver-deployment.yaml
@@ -186,7 +186,10 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
-        {{- if $webapp.custom_liveness_probe }}
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else if $webapp.custom_liveness_probe }}
         {{ $webapp.custom_liveness_probe | toYaml | nindent 8 }}
         {{- else }}
         livenessProbe:
@@ -199,6 +202,14 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           httpGet:
             path: /geoserver/ows?SERVICE=WMS&REQUEST=DescribeLayer&LAYERS=geor:public_layer&VERSION=1.1.1
@@ -209,6 +220,7 @@ spec:
           failureThreshold: 10
           periodSeconds: 10
           timeoutSeconds: 5
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/geoserver/geoserver-deployment.yaml
+++ b/georchestra/templates/geoserver/geoserver-deployment.yaml
@@ -189,8 +189,6 @@ spec:
         {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
-        {{- else if $webapp.custom_liveness_probe }}
-        {{ $webapp.custom_liveness_probe | toYaml | nindent 8 }}
         {{- else }}
         livenessProbe:
           httpGet:

--- a/georchestra/templates/geoserver/geoserver-deployment.yaml
+++ b/georchestra/templates/geoserver/geoserver-deployment.yaml
@@ -186,7 +186,7 @@ spec:
         ports:
         - containerPort: 8080
           name: http-proxy
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else if $webapp.custom_liveness_probe }}
@@ -202,11 +202,11 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/geowebcache/geowebcache-deployment.yaml
+++ b/georchestra/templates/geowebcache/geowebcache-deployment.yaml
@@ -74,7 +74,10 @@ spec:
         ports:
         - containerPort: 8080
           name: http
-        {{- if $webapp.livenessProbe }}
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else if $webapp.livenessProbe }}
         {{ $webapp.livenessProbe | toYaml | nindent 8 }}
         {{- else }}
         livenessProbe:
@@ -84,6 +87,14 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           failureThreshold: 5
           httpGet:
@@ -93,6 +104,7 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 1
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/geowebcache/geowebcache-deployment.yaml
+++ b/georchestra/templates/geowebcache/geowebcache-deployment.yaml
@@ -74,7 +74,7 @@ spec:
         ports:
         - containerPort: 8080
           name: http
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else if $webapp.livenessProbe }}
@@ -87,11 +87,11 @@ spec:
           periodSeconds: 10
           timeoutSeconds: 5
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/geowebcache/geowebcache-deployment.yaml
+++ b/georchestra/templates/geowebcache/geowebcache-deployment.yaml
@@ -77,8 +77,6 @@ spec:
         {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
-        {{- else if $webapp.livenessProbe }}
-        {{ $webapp.livenessProbe | toYaml | nindent 8 }}
         {{- else }}
         livenessProbe:
           httpGet:

--- a/georchestra/templates/header/header-deployment.yaml
+++ b/georchestra/templates/header/header-deployment.yaml
@@ -54,7 +54,7 @@ spec:
         ports:
         - containerPort: 8080
           name: http
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -64,11 +64,11 @@ spec:
             port: http
             scheme: HTTP
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/header/header-deployment.yaml
+++ b/georchestra/templates/header/header-deployment.yaml
@@ -54,11 +54,24 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /header/
             port: http
             scheme: HTTP
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           failureThreshold: 5
           httpGet:
@@ -69,6 +82,7 @@ spec:
           periodSeconds: 15
           successThreshold: 1
           timeoutSeconds: 1
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/ldap/openldap-deployment.yaml
+++ b/georchestra/templates/ldap/openldap-deployment.yaml
@@ -63,7 +63,7 @@ spec:
           {{- if $webapp.extraVolumeMounts }}
             {{- toYaml $webapp.extraVolumeMounts | nindent 10 }}
           {{- end }}
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -77,11 +77,11 @@ spec:
             - {{ .Values.ldap.adminDn }}
           initialDelaySeconds: 30
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- end }}

--- a/georchestra/templates/ldap/openldap-deployment.yaml
+++ b/georchestra/templates/ldap/openldap-deployment.yaml
@@ -63,6 +63,10 @@ spec:
           {{- if $webapp.extraVolumeMounts }}
             {{- toYaml $webapp.extraVolumeMounts | nindent 10 }}
           {{- end }}
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           exec:
             command:
@@ -72,6 +76,15 @@ spec:
             - -b{{ .Values.ldap.baseDn }}
             - {{ .Values.ldap.adminDn }}
           initialDelaySeconds: 30
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/mapstore/mapstore-deployment.yaml
+++ b/georchestra/templates/mapstore/mapstore-deployment.yaml
@@ -68,17 +68,31 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           httpGet:
             path: /mapstore/configs/config.json
             port: 8080
           periodSeconds: 10
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           httpGet:
             path: /mapstore/configs/config.json
             port: 8080
           failureThreshold: 5
           periodSeconds: 15
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/mapstore/mapstore-deployment.yaml
+++ b/georchestra/templates/mapstore/mapstore-deployment.yaml
@@ -68,7 +68,7 @@ spec:
         lifecycle:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -78,11 +78,11 @@ spec:
             port: 8080
           periodSeconds: 10
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/rabbitmq/rabbitmq-deployment.yaml
+++ b/georchestra/templates/rabbitmq/rabbitmq-deployment.yaml
@@ -56,6 +56,10 @@ spec:
         volumeMounts:
         - name: rabbitmq-data
           mountPath: /var/lib/rabbitmq
+        {{- if $rabbitmq.probes.livenessProbe }}
+        livenessProbe:
+          {{- $rabbitmq.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           exec:
             command:
@@ -66,6 +70,11 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 20
           failureThreshold: 6
+        {{- end }}
+        {{- if $rabbitmq.probes.readinessProbe }}
+        readinessProbe:
+          {{- $rabbitmq.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- else }}
         readinessProbe:
           exec:
             command:
@@ -76,6 +85,11 @@ spec:
           periodSeconds: 30
           timeoutSeconds: 20
           failureThreshold: 3
+        {{- end }}
+        {{- if $rabbitmq.probes.startupProbe }}
+        startupProbe:
+          {{- $rabbitmq.probes.startupProbe | toYaml | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml $rabbitmq.resources | nindent 10 }}
       volumes:

--- a/georchestra/templates/rabbitmq/rabbitmq-deployment.yaml
+++ b/georchestra/templates/rabbitmq/rabbitmq-deployment.yaml
@@ -56,7 +56,7 @@ spec:
         volumeMounts:
         - name: rabbitmq-data
           mountPath: /var/lib/rabbitmq
-        {{- if $rabbitmq.probes.livenessProbe }}
+        {{- if and $rabbitmq.probes $rabbitmq.probes.livenessProbe }}
         livenessProbe:
           {{- $rabbitmq.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -71,7 +71,7 @@ spec:
           timeoutSeconds: 20
           failureThreshold: 6
         {{- end }}
-        {{- if $rabbitmq.probes.readinessProbe }}
+        {{- if and $rabbitmq.probes $rabbitmq.probes.readinessProbe }}
         readinessProbe:
           {{- $rabbitmq.probes.readinessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -86,7 +86,7 @@ spec:
           timeoutSeconds: 20
           failureThreshold: 3
         {{- end }}
-        {{- if $rabbitmq.probes.startupProbe }}
+        {{- if and $rabbitmq.probes $rabbitmq.probes.startupProbe }}
         startupProbe:
           {{- $rabbitmq.probes.startupProbe | toYaml | nindent 10 }}
         {{- end }}

--- a/georchestra/templates/security-proxy/security-proxy-deployment.yaml
+++ b/georchestra/templates/security-proxy/security-proxy-deployment.yaml
@@ -67,16 +67,30 @@ spec:
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           tcpSocket:
             port: 8080
           failureThreshold: 5
           periodSeconds: 15
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- else }}
         startupProbe:
           tcpSocket:
             port: 8080
           failureThreshold: 5
           periodSeconds: 15
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.extraContainers }}

--- a/georchestra/templates/security-proxy/security-proxy-deployment.yaml
+++ b/georchestra/templates/security-proxy/security-proxy-deployment.yaml
@@ -67,7 +67,7 @@ spec:
         volumeMounts:
           - mountPath: /etc/georchestra
             name: georchestra-datadir
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -77,11 +77,11 @@ spec:
           failureThreshold: 5
           periodSeconds: 15
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- else }}

--- a/georchestra/templates/smtp-smarthost/smtp-deployment.yaml
+++ b/georchestra/templates/smtp-smarthost/smtp-deployment.yaml
@@ -65,10 +65,23 @@ spec:
         ports:
         - containerPort: 25
           name: smtp
+        {{- if $webapp.probes.livenessProbe }}
+        livenessProbe:
+          {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
+        {{- else }}
         livenessProbe:
           tcpSocket:
             port: smtp
           initialDelaySeconds: 30
+        {{- end }}
+        {{- if $webapp.probes.readinessProbe }}
+        readinessProbe:
+          {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if $webapp.probes.startupProbe }}
+        startupProbe:
+          {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
+        {{- end }}
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}
       {{- if $webapp.tolerations }}

--- a/georchestra/templates/smtp-smarthost/smtp-deployment.yaml
+++ b/georchestra/templates/smtp-smarthost/smtp-deployment.yaml
@@ -65,7 +65,7 @@ spec:
         ports:
         - containerPort: 25
           name: smtp
-        {{- if $webapp.probes.livenessProbe }}
+        {{- if and $webapp.probes $webapp.probes.livenessProbe }}
         livenessProbe:
           {{- $webapp.probes.livenessProbe | toYaml | nindent 10 }}
         {{- else }}
@@ -74,11 +74,11 @@ spec:
             port: smtp
           initialDelaySeconds: 30
         {{- end }}
-        {{- if $webapp.probes.readinessProbe }}
+        {{- if and $webapp.probes $webapp.probes.readinessProbe }}
         readinessProbe:
           {{- $webapp.probes.readinessProbe | toYaml | nindent 10 }}
         {{- end }}
-        {{- if $webapp.probes.startupProbe }}
+        {{- if and $webapp.probes $webapp.probes.startupProbe }}
         startupProbe:
           {{- $webapp.probes.startupProbe | toYaml | nindent 10 }}
         {{- end }}

--- a/georchestra/values.yaml
+++ b/georchestra/values.yaml
@@ -25,6 +25,18 @@ georchestra:
       service:
         annotations: {}
       tolerations: []
+      # Example webapp probes override :
+      # probes:
+      #   livenessProbe:
+      #     httpGet:
+      #       path: /analytics/
+      #       port: 8080
+      #     periodSeconds: 10
+      #   startupProbe:
+      #     tcpSocket:
+      #       port: 8080
+      #     failureThreshold: 5
+      #     periodSeconds: 10
       resources:
         requests:
           cpu: 100m


### PR DESCRIPTION
This PR add the ability to override probes for every deployment via the `values.yaml`.

```yaml
# Example webapp probes override :
# probes:
#   livenessProbe:
#     httpGet:
#       path: /analytics/
#       port: 8080
#     periodSeconds: 10
#   startupProbe:
#     tcpSocket:
#       port: 8080
#     failureThreshold: 5
#     periodSeconds: 10
```

And remove old ways to set livenessprobe on geowebcache and geoserver.