### PR TITLE
chore: Increase failure threshold for startup probe

### DIFF
--- a/georchestra/templates/mapstore/mapstore-deployment.yaml
+++ b/georchestra/templates/mapstore/mapstore-deployment.yaml
@@ -77,7 +77,7 @@ spec:
           httpGet:
             path: /mapstore/configs/config.json
             port: 8080
-          failureThreshold: 5
+          failureThreshold: 10
           periodSeconds: 15
         resources:
           {{- toYaml $webapp.resources | nindent 10 }}


### PR DESCRIPTION
in order to have mapstore startupprobes working on weaker setup

helps with https://github.com/georchestra/helm-charts/issues/216