### PR TITLE
feat: add analytics helm chart

### DIFF
--- a/analytics/.helmignore
+++ b/analytics/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/analytics/Chart.yaml
+++ b/analytics/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+name: analytics
+description: A Helm chart geOrchestra Analytics module
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 1.0.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.0.0rc1"
+
+# dependencies:
+# - name: vector
+#   version: 0.42.1
+#   repository: "https://helm.vector.dev"
+#   condition: vector.enabled
+#   alias: vector

--- a/analytics/README.md
+++ b/analytics/README.md
@@ -1,0 +1,3 @@
+Code source of the original project: https://github.com/georchestra/analytics
+
+See https://docs.georchestra.org/analytics/technical_guides/installation/ for the documentation.

--- a/analytics/templates/_helpers-database.tpl
+++ b/analytics/templates/_helpers-database.tpl
@@ -1,0 +1,44 @@
+{{/*
+Name of the TimescaleDB connection secret.
+*/}}
+{{- define "analytics.timescaledb-connection-secret-name" -}}
+{{- .Values.timescaledb.auth.existingSecret | default (printf "%s-timescaledb-connection-secret" (include "analytics.fullname" .)) -}}
+{{- end }}
+
+{{/*
+Name of the TimescaleDB env secret.
+*/}}
+{{- define "analytics.timescaledb-env-secret-name" -}}
+{{- .Values.timescaledb.auth.existingEnvSecret | default (printf "%s-timescaledb-env-secret" (include "analytics.fullname" .)) -}}
+{{- end }}
+
+{{/*
+TimescaleDB TSDB_* environment variables (list items to include under env:).
+*/}}
+{{- define "analytics.timescaledb-envs" -}}
+- name: TSDB_HOST
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "analytics.timescaledb-connection-secret-name" . | quote }}
+      key: host
+- name: TSDB_PORT
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "analytics.timescaledb-connection-secret-name" . | quote }}
+      key: port
+- name: TSDB_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "analytics.timescaledb-connection-secret-name" . | quote }}
+      key: dbname
+- name: TSDB_USER
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "analytics.timescaledb-connection-secret-name" . | quote }}
+      key: user
+- name: TSDB_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "analytics.timescaledb-connection-secret-name" . | quote }}
+      key: password
+{{- end }}

--- a/analytics/templates/_helpers.tpl
+++ b/analytics/templates/_helpers.tpl
@@ -1,0 +1,52 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "analytics.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "analytics.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "analytics.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "analytics.labels" -}}
+helm.sh/chart: {{ include "analytics.chart" . }}
+{{ include "analytics.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "analytics.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "analytics.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+

--- a/analytics/templates/cli/cli-configmap.yaml
+++ b/analytics/templates/cli/cli-configmap.yaml
@@ -1,0 +1,37 @@
+{{- $webapp := .Values.cli -}}
+{{- if $webapp.enabled -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "analytics.fullname" . }}-cli-config
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-cli
+data:
+  cli.yaml: |
+    database:
+      drivername: "postgresql"
+      host: !ENV "${TSDB_HOST:localhost}"
+      port: !ENV "${TSDB_PORT:5433}"
+      database: !ENV "${TSDB_NAME:analytics}"
+      username: !ENV "${TSDB_USER:tsdb}"
+      password: !ENV "${TSDB_PASSWORD:secret}"
+
+    metrics:
+      {{- toYaml $webapp.config.metrics | nindent 6 }}
+
+    performance:
+      {{- toYaml $webapp.config.performance | nindent 6 }}
+
+    timezone: {{ $webapp.config.timezone | quote }}
+
+    apps_mapping:
+      {{- toYaml $webapp.config.appsMapping | nindent 6 }}
+
+    parsers:
+    {{- $webapp.config.parsers | nindent 6 }}
+
+    logging:
+      {{- toYaml $webapp.config.logging | nindent 6 }}
+{{- end }}

--- a/analytics/templates/cli/cli-cronjob.yaml
+++ b/analytics/templates/cli/cli-cronjob.yaml
@@ -1,0 +1,91 @@
+{{- $webapp := .Values.cli -}}
+{{- if $webapp.enabled -}}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "analytics.fullname" . }}-cli-cronjob
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-cli
+spec:
+  concurrencyPolicy: Forbid
+  schedule: {{ $webapp.schedule | quote }}
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 1
+      template:
+        metadata:
+          annotations:
+            checksum/config: {{ include (print $.Template.BasePath "/cli/cli-configmap.yaml") . | sha256sum }}
+            {{- with $webapp.podAnnotations }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          labels:
+            {{- include "analytics.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: {{ include "analytics.fullname" . }}-cli
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml $webapp.podSecurityContext | nindent 12 }}
+          {{- with $webapp.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $webapp.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $webapp.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+          - name: analytics-cli
+            image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
+            imagePullPolicy: {{ $webapp.image.pullPolicy }}
+            securityContext:
+              {{- toYaml $webapp.securityContext | nindent 14 }}
+            command: ["analytics-cli"]
+            args:
+            {{- if $webapp.fakeRecords.enabled }}
+              - "fake2db"
+              - "--last_n_hours"
+              - {{ $webapp.fakeRecords.coverDurationHours | quote }}
+              - "--rate"
+              - {{ $webapp.fakeRecords.maxRate | quote }}
+            {{- else }}
+              - "buffer2db"
+            {{- end }}
+            envFrom:
+              - secretRef:
+                  name: {{ include "analytics.timescaledb-env-secret-name" . | quote }}
+            env:
+              {{- include "analytics.timescaledb-envs" . | nindent 14 }}
+              - name: GEORCHESTRA_ANALYTICS_CLI_CONFIG_FILE
+                value: /etc/georchestra/analytics/cli.yaml
+              {{- with $webapp.extraEnv }}
+              {{- toYaml . | nindent 14 }}
+              {{- end }}
+            resources:
+              {{- toYaml $webapp.resources | nindent 14 }}
+            volumeMounts:
+            - name: cli-config
+              subPath: cli.yaml
+              mountPath: /etc/georchestra/analytics/cli.yaml
+            {{- with $webapp.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          restartPolicy: Never
+          volumes:
+          - name: cli-config
+            configMap:
+              name: {{ include "analytics.fullname" . }}-cli-config
+          {{- with $webapp.extraVolumes }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+{{- end }}

--- a/analytics/templates/sync-dashboards/sync-dashboards-job.yaml
+++ b/analytics/templates/sync-dashboards/sync-dashboards-job.yaml
@@ -1,0 +1,82 @@
+{{- $webapp := .Values.syncDashboards -}}
+{{- if $webapp.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "analytics.fullname" . }}-sync-dashboards
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-sync-dashboards
+  {{- if $webapp.useHelmHooks }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-delete-policy": before-hook-creation
+  {{- else }}
+  annotations:
+    {{- with $webapp.jobAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  backoffLimit: {{ $webapp.backoffLimit | default 1 }}
+  ttlSecondsAfterFinished: {{ $webapp.ttlSecondsAfterFinished | default 300 }}
+  template:
+    metadata:
+      labels:
+        {{- include "analytics.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: {{ include "analytics.fullname" . }}-sync-dashboards
+      {{- with $webapp.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml $webapp.podSecurityContext | nindent 8 }}
+      {{- with $webapp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $webapp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $webapp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+      - name: sync-dashboards
+        image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
+        imagePullPolicy: {{ $webapp.image.pullPolicy }}
+        securityContext:
+          {{- toYaml $webapp.securityContext | nindent 10 }}
+        {{- with $webapp.args }}
+        args:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        env:
+        - name: SUPERSET_URL
+          value: {{ $webapp.supersetUrl | quote }}
+        - name: ANALYTICS_DB_URI
+          value: "postgresql://$(TSDB_USER):$(TSDB_PASSWORD)@$(TSDB_HOST):$(TSDB_PORT)/$(TSDB_NAME)"
+        {{- include "analytics.timescaledb-envs" . | nindent 8 }}
+        {{- with $webapp.extraEnv }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        resources:
+          {{- toYaml $webapp.resources | nindent 10 }}
+        {{- with $webapp.extraVolumeMounts }}
+        volumeMounts:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+      restartPolicy: Never
+      {{- with $webapp.extraVolumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/analytics/templates/timescaledb/timescaledb-connection-secret.yaml
+++ b/analytics/templates/timescaledb/timescaledb-connection-secret.yaml
@@ -1,0 +1,20 @@
+{{- $database := .Values.timescaledb -}}
+{{- if not $database.auth.existingSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "analytics.fullname" . }}-timescaledb-connection-secret
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+type: Opaque
+data:
+  dbname: {{ $database.auth.database | b64enc | quote }}
+  {{- if $database.builtin }}
+  host: {{ printf "%s-timescaledb-svc" (include "analytics.fullname" .) | b64enc | quote  }}
+  {{- else }}
+  host: {{ $database.auth.host | b64enc | quote }}
+  {{- end }}
+  password: {{ $database.auth.password | b64enc | quote }}
+  port: {{ $database.auth.port | b64enc | quote }}
+  user: {{ $database.auth.username | b64enc | quote }}
+{{- end }}

--- a/analytics/templates/timescaledb/timescaledb-deployment.yaml
+++ b/analytics/templates/timescaledb/timescaledb-deployment.yaml
@@ -1,0 +1,119 @@
+{{- $webapp := .Values.timescaledb -}}
+{{- if $webapp.builtin -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "analytics.fullname" . }}-timescaledb
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-timescaledb
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "analytics.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ include "analytics.fullname" . }}-timescaledb
+  template:
+    metadata:
+      annotations:
+        checksum/initscripts: {{ include (print $.Template.BasePath "/timescaledb/timescaledb-initscripts-configmap.yaml") . | sha256sum }}
+        {{- with $webapp.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "analytics.selectorLabels" . | nindent 8 }}
+        org.georchestra.service/name: {{ include "analytics.fullname" . }}-timescaledb
+        app.kubernetes.io/component: {{ include "analytics.fullname" . }}-timescaledb
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml $webapp.podSecurityContext | nindent 8 }}
+      {{- with $webapp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $webapp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $webapp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: analytics-timescaledb
+          image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
+          imagePullPolicy: {{ $webapp.image.pullPolicy }}
+          securityContext:
+            {{- toYaml $webapp.securityContext | nindent 12 }}
+          {{- with $webapp.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: postgresql
+              containerPort: 5432
+              protocol: TCP
+          env:
+            - name: POSTGRES_DB
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "analytics.timescaledb-connection-secret-name" . | quote }}
+                  key: dbname
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "analytics.timescaledb-connection-secret-name" . | quote }}
+                  key: user
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "analytics.timescaledb-connection-secret-name" . | quote }}
+                  key: password
+            {{- with $webapp.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - mountPath: /home/postgres/pgdata
+              name: timescaledb-data
+            - mountPath: /docker-entrypoint-initdb.d/100_analytics_init.sql
+              name: timescaledb-initscripts
+              subPath: 100_analytics_init.sql
+            - mountPath: /docker-entrypoint-initdb.d/101_analytics_ogc_views.sql
+              name: timescaledb-initscripts
+              subPath: 101_analytics_ogc_views.sql
+            {{- with $webapp.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          startupProbe:
+            exec:
+              command: ["bash", "-c", "psql -w -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'"]
+            failureThreshold: 30
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["bash", "-c", "psql -w -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'"]
+            periodSeconds: 10
+          readinessProbe:
+            exec:
+              command: ["bash", "-c", "psql -w -U $POSTGRES_USER -d $POSTGRES_DB -c 'SELECT 1'"]
+            periodSeconds: 10
+          resources:
+            {{- toYaml $webapp.resources | nindent 12 }}
+      volumes:
+      - name: timescaledb-data
+        persistentVolumeClaim:
+          claimName: {{ include "analytics.fullname" . }}-timescaledb-data
+      - name: timescaledb-initscripts
+        configMap:
+          name: {{ include "analytics.fullname" . }}-timescaledb-initscripts
+      {{- with $webapp.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+
+{{- end }}

--- a/analytics/templates/timescaledb/timescaledb-env-secret.yaml
+++ b/analytics/templates/timescaledb/timescaledb-env-secret.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.timescaledb.auth.existingEnvSecret -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "analytics.fullname" . }}-timescaledb-env-secret
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-timescaledb
+type: Opaque
+data:
+  TSDB_OTEL_TABLE: {{ .Values.timescaledb.dbOpentelemetryTable | b64enc | quote }}
+{{- end }}

--- a/analytics/templates/timescaledb/timescaledb-initscripts-configmap.yaml
+++ b/analytics/templates/timescaledb/timescaledb-initscripts-configmap.yaml
@@ -1,0 +1,223 @@
+{{- $webapp := .Values.timescaledb -}}
+{{- if $webapp.builtin -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "analytics.fullname" . }}-timescaledb-initscripts
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-timescaledb
+data:
+  100_analytics_init.sql: |-
+    CREATE SCHEMA IF NOT EXISTS analytics;
+    SET search_path = analytics, public;
+    CREATE UNLOGGED TABLE IF NOT EXISTS analytics.opentelemetry_buffer
+    (
+        timestamp                   timestamptz,
+        span_id                     text,
+        trace_id                    text,
+        message                     text,
+        attributes                  jsonb,
+        resources                   jsonb,
+        scope                       jsonb,
+        source_type                 text,
+        severity_text               text,
+        severity_number             integer,
+        observed_timestamp          timestamptz,
+        flags                       integer,
+        dropped_attributes_count    integer
+    );
+    COMMENT ON TABLE analytics.opentelemetry_buffer IS 'Opentelemetry buffer table. Receives incoming opentelemetry logs data, for further processing and proper storage. Only contains transient data.';
+    
+    CREATE TABLE IF NOT EXISTS analytics.access_logs
+    (
+        oid                  serial,
+        id                   text,
+        ts                   timestamptz NOT NULL,
+        message              text        NOT NULL,
+        app_id               text        NOT NULL,
+        app_path             text        NOT NULL,
+        app_name             text        NOT NULL,
+        ip                   text,
+        user_id              text,
+        user_name            text,
+        org_id               text,
+        org_name             text,
+        roles                text[],
+        auth_method          text,
+        request_method       text,
+        request_path         text,
+        request_query_string text,
+        request_details      jsonb,
+        response_time        integer,
+        response_size        integer,
+        status_code          integer,
+        client_ip            text,
+        server_address       text,
+        context_data         jsonb,
+        PRIMARY KEY (ts, oid)
+    );
+    SELECT create_hypertable('analytics.access_logs', by_range('ts', INTERVAL '7 days'));
+    COMMENT ON TABLE analytics.access_logs IS 'Storage (hyper)table for the access logs processed data. This is a timescaledb-enabled table.';
+    
+    CREATE UNIQUE INDEX idx_id_timestamp
+      ON analytics.access_logs(ts, id);
+    
+    -- Set retention policy to 3 years, see https://docs.timescale.com/api/latest/data-retention/add_retention_policy/#add_retention_policy
+    SELECT add_retention_policy('analytics.access_logs', drop_after => INTERVAL '3 years', schedule_interval => INTERVAL '1 week');
+    
+    -- set compression
+    -- see https://docs.timescale.com/api/latest/compression/alter_table_compression/
+    --     https://docs.timescale.com/use-timescale/latest/compression/compression-policy/
+    ALTER TABLE access_logs SET (
+      timescaledb.compress,
+      timescaledb.compress_segmentby = 'id'
+    );
+    SELECT add_compression_policy('access_logs', compress_after => INTERVAL '1 month');
+  101_analytics_ogc_views.sql: |-
+    SET search_path = analytics, public;
+    
+    CREATE MATERIALIZED VIEW analytics.ogc_summary_hourly
+    WITH (timescaledb.continuous) AS
+    SELECT time_bucket(INTERVAL '1 h', ts, '{{ $webapp.timezone }}') AS bucket_hourly,
+        app_id,
+        app_name,
+        user_name,
+        org_name,
+        request_method,
+        status_code,
+        server_address,
+        request_details ->> 'workspaces' AS workspaces,
+        request_details ->> 'layers' AS layers,
+        request_details ->> 'service'            AS service,
+        request_details ->> 'request'            AS request,
+        request_details ->> 'tiled'              AS tiled,
+        request_details ->> 'is_download'       AS is_download,
+        request_details ->> 'download_format'   AS download_format,
+        request_details ->> 'user_agent_family' AS user_agent_family,
+        count(id)                               AS nb_req,
+        AVG(response_time)                      AS avg_time,
+        percentile_agg(response_time::DOUBLE PRECISION)         AS percentile_hourly
+    FROM analytics.access_logs
+    WHERE request_details ->'tags' @> '["ogc"]'
+    GROUP BY bucket_hourly, app_id, app_name, user_name, org_name, request_method, status_code, server_address,
+        request_details ->> 'workspaces', request_details ->> 'layers',
+        request_details ->> 'service', request_details ->> 'request' , request_details ->> 'tiled',
+        request_details ->> 'is_download', request_details ->> 'download_format', request_details ->> 'user_agent_family';
+    
+    -- for explanations about the percentile_agg see
+    -- https://docs.timescale.com/use-timescale/latest/continuous-aggregates/hierarchical-continuous-aggregates/#roll-up-calculations
+    
+    
+    SELECT add_retention_policy('analytics.ogc_summary_hourly', drop_after => INTERVAL '3 weeks', schedule_interval => INTERVAL '1 day');
+    
+    -- set compression
+    -- see https://docs.timescale.com/use-timescale/latest/continuous-aggregates/compression-on-continuous-aggregates/
+    SELECT add_continuous_aggregate_policy('analytics.ogc_summary_hourly',
+      initial_start => '2025-11-11 00:05:05',
+      start_offset => INTERVAL '7 days',
+      end_offset => INTERVAL '0 hours',
+      schedule_interval => INTERVAL '1 hour');
+    ALTER MATERIALIZED VIEW analytics.ogc_summary_hourly set (timescaledb.compress = true);
+    SELECT add_compression_policy('analytics.ogc_summary_hourly', compress_after=>'4 days'::interval);
+    
+    
+    CREATE MATERIALIZED VIEW analytics.ogc_summary_daily
+    WITH (timescaledb.continuous) AS
+    SELECT  time_bucket(INTERVAL '1 d', bucket_hourly, '{{ $webapp.timezone }}') AS bucket_daily,
+        app_id,
+        app_name,
+        user_name,
+        org_name,
+        request_method,
+        status_code,
+        server_address,
+        workspaces,
+        layers,
+        service,
+        request,
+        tiled,
+        is_download,
+        download_format,
+        user_agent_family,
+        SUM(nb_req)                       AS nb_req,
+        mean(rollup(percentile_hourly))   AS avg_time,
+        rollup(percentile_hourly) as percentile_daily
+    FROM analytics.ogc_summary_hourly
+    GROUP BY bucket_daily, app_id, app_name, user_name, org_name, request_method, status_code, server_address, workspaces,
+         layers, service, request, tiled, is_download, download_format, user_agent_family;
+    
+    SELECT add_retention_policy('analytics.ogc_summary_daily', drop_after => INTERVAL '2 years', schedule_interval => INTERVAL '1 week');
+    
+    -- set compression
+    -- see https://docs.timescale.com/use-timescale/latest/continuous-aggregates/compression-on-continuous-aggregates/
+    SELECT add_continuous_aggregate_policy('analytics.ogc_summary_daily',
+      initial_start => '2025-11-11 00:00:05',
+      start_offset => INTERVAL '3 weeks',
+      end_offset => INTERVAL '0 hours',
+      schedule_interval => INTERVAL '1 d');
+    ALTER MATERIALIZED VIEW analytics.ogc_summary_daily set (timescaledb.compress = true);
+    SELECT add_compression_policy('analytics.ogc_summary_daily', compress_after=>'4 weeks'::interval);
+    
+    
+    
+    CREATE MATERIALIZED VIEW analytics.ogc_summary_monthly
+    WITH (timescaledb.continuous) AS
+    SELECT  time_bucket(INTERVAL '1 month', bucket_daily, '{{ $webapp.timezone }}') AS bucket_monthly,
+        app_id,
+        app_name,
+        user_name,
+        org_name,
+        request_method,
+        status_code,
+        server_address,
+        workspaces,
+        layers,
+        service,
+        request,
+        tiled,
+        is_download,
+        download_format,
+        user_agent_family,
+        SUM(nb_req)                      AS nb_req,
+        mean(rollup(percentile_daily))   AS avg_time,
+        rollup(percentile_daily) as percentile_monthly
+    FROM analytics.ogc_summary_daily
+    GROUP BY bucket_monthly, app_id, app_name, user_name, org_name, request_method, status_code, server_address, workspaces,
+         layers, service, request, tiled, is_download, download_format, user_agent_family;
+    
+    -- set compression
+    -- see https://docs.timescale.com/use-timescale/latest/continuous-aggregates/compression-on-continuous-aggregates/
+    SELECT add_continuous_aggregate_policy('analytics.ogc_summary_monthly',
+      initial_start => '2025-11-11 00:00:05',
+      start_offset => INTERVAL '6 months',
+      end_offset => INTERVAL '0 hours',
+      schedule_interval => INTERVAL '1 month');
+    ALTER MATERIALIZED VIEW analytics.ogc_summary_monthly set (timescaledb.compress = true);
+    SELECT add_compression_policy('analytics.ogc_summary_monthly', compress_after=>'7 months'::interval);
+    
+    
+    CALL refresh_continuous_aggregate('analytics.ogc_summary_hourly', '2021-05-01', '2026-05-14');
+    CALL refresh_continuous_aggregate('analytics.ogc_summary_daily', '2021-05-01', '2026-05-14');
+    CALL refresh_continuous_aggregate('analytics.ogc_summary_monthly', '2021-05-01', '2026-05-14');
+    
+    
+    -- Watch retention policies state (see https://docs.timescale.com/api/latest/data-retention/add_retention_policy/#add_retention_policy):
+    -- SELECT j.hypertable_name,                                                                       
+    --        j.job_id,
+    --        config,
+    --        schedule_interval,
+    --        job_status,
+    --        last_run_status,
+    --        last_run_started_at,
+    --        js.next_start,
+    --        total_runs,
+    --        total_successes,
+    --        total_failures
+    --   FROM timescaledb_information.jobs j
+    --   JOIN timescaledb_information.job_stats js
+    --     ON j.job_id = js.job_id
+    --   WHERE j.proc_name = 'policy_retention';
+
+{{- end }}

--- a/analytics/templates/timescaledb/timescaledb-initscripts-configmap.yaml
+++ b/analytics/templates/timescaledb/timescaledb-initscripts-configmap.yaml
@@ -74,7 +74,7 @@ data:
       timescaledb.compress,
       timescaledb.compress_segmentby = 'id'
     );
-    SELECT add_compression_policy('access_logs', compress_after => INTERVAL '1 month');
+    SELECT add_compression_policy('access_logs', compress_after => INTERVAL '1 day');
   101_analytics_ogc_views.sql: |-
     SET search_path = analytics, public;
     

--- a/analytics/templates/timescaledb/timescaledb-pvc.yaml
+++ b/analytics/templates/timescaledb/timescaledb-pvc.yaml
@@ -1,0 +1,34 @@
+{{- $webapp := .Values.timescaledb -}}
+{{- if $webapp.builtin -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "analytics.fullname" . }}-timescaledb-data
+  {{- with $webapp.persistence.annotations }}
+  annotations:
+    {{- range $key, $value := . }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
+  {{- end }}
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-timescaledb
+spec:
+  accessModes:
+    {{- range $webapp.persistence.accessModes }}
+    - {{ . | quote }}
+    {{- end }}
+  resources:
+    requests:
+      storage: {{ $webapp.persistence.size }}
+  {{- if $webapp.persistence.storageClass }}
+  {{- if eq "-" $webapp.persistence.storageClass }}
+  storageClassName: ""
+  {{- else }}
+  storageClassName: {{ $webapp.persistence.storageClass }}
+  {{- end }}
+  {{- end }}
+  {{- if $webapp.persistence.existingPV }}
+  volumeName: {{ $webapp.persistence.existingPV }}
+  {{- end }}
+{{- end }}

--- a/analytics/templates/timescaledb/timescaledb-service.yaml
+++ b/analytics/templates/timescaledb/timescaledb-service.yaml
@@ -1,0 +1,19 @@
+{{- $webapp := .Values.timescaledb -}}
+{{- if $webapp.builtin -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "analytics.fullname" . }}-timescaledb-svc
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-timescaledb
+spec:
+  ports:
+    - name: postgresql
+      port: 5432
+      targetPort: postgresql
+      protocol: TCP
+  selector:
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-timescaledb
+
+{{- end }}

--- a/analytics/templates/vector/vector-configmap.yaml
+++ b/analytics/templates/vector/vector-configmap.yaml
@@ -12,15 +12,15 @@ data:
   default.yaml: |
     api:
       enabled: true
-      address: [::]:8686
+      address: "[::]:8686"
 
     sources:
       opentelemetry:
         type: opentelemetry
         grpc:
-          address: [::]:4317
+          address: "[::]:4317"
         http:
-          address: [::]:4318
+          address: "[::]:4318"
           headers: []
           keepalive:
             max_connection_age_jitter_factor: 0.1

--- a/analytics/templates/vector/vector-configmap.yaml
+++ b/analytics/templates/vector/vector-configmap.yaml
@@ -1,0 +1,40 @@
+{{- $webapp := .Values.vector -}}
+{{- if $webapp.enabled -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "analytics.fullname" . }}-vector-config
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-vector
+data:
+  default.yaml: |
+    api:
+      enabled: true
+      address: [::]:8686
+
+    sources:
+      opentelemetry:
+        type: opentelemetry
+        grpc:
+          address: [::]:4317
+        http:
+          address: [::]:4318
+          headers: []
+          keepalive:
+            max_connection_age_jitter_factor: 0.1
+            max_connection_age_secs: 300
+
+    sinks:
+      tsdb:
+        type: postgres
+        # Listen to a "hook" transform that will be defined in the custom file
+        inputs: 
+          - tsdb_input
+        endpoint: "postgres://${TSDB_USER}:${TSDB_PASSWORD}@${TSDB_HOST}:${TSDB_PORT}/${TSDB_NAME}"
+        table: "${TSDB_OTEL_TABLE:-analytics.opentelemetry_buffer}"
+        pool_size: 5
+  custom.yaml: |
+    {{- toYaml $webapp.config | nindent 4 }}
+{{- end }}

--- a/analytics/templates/vector/vector-deployment.yaml
+++ b/analytics/templates/vector/vector-deployment.yaml
@@ -1,0 +1,107 @@
+{{- $webapp := .Values.vector -}}
+{{- if $webapp.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "analytics.fullname" . }}-vector
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-vector
+spec:
+  replicas: {{ $webapp.replicaCount | default 1 }}
+  strategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "analytics.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: {{ include "analytics.fullname" . }}-vector
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/vector/vector-configmap.yaml") . | sha256sum }}
+        {{- with $webapp.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "analytics.selectorLabels" . | nindent 8 }}
+        org.georchestra.service/name: {{ include "analytics.fullname" . }}-vector
+        app.kubernetes.io/component: {{ include "analytics.fullname" . }}-vector
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml $webapp.podSecurityContext | nindent 8 }}
+      {{- with $webapp.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $webapp.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $webapp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: analytics-vector
+          image: "{{ $webapp.image.repository }}:{{ $webapp.image.tag }}"
+          imagePullPolicy: {{ $webapp.image.pullPolicy }}
+          securityContext:
+            {{- toYaml $webapp.securityContext | nindent 12 }}
+          {{- with $webapp.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: grpc
+              containerPort: 4317
+              protocol: TCP
+            - name: http
+              containerPort: 4318
+              protocol: TCP
+            - name: api
+              containerPort: 8686
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: {{ include "analytics.timescaledb-env-secret-name" . | quote }}
+          env:
+            - name: VECTOR_CONFIG
+              value: "/etc/vector/*.yaml"
+            {{- include "analytics.timescaledb-envs" . | nindent 12 }}
+            {{- with $webapp.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          volumeMounts:
+            - mountPath: /etc/vector
+              name: vector-config
+              readOnly: true
+            {{- with $webapp.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: api
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: api
+            initialDelaySeconds: 15
+            periodSeconds: 10
+          resources:
+            {{- toYaml $webapp.resources | nindent 12 }}
+      volumes:
+      - name: vector-config
+        configMap:
+          name: {{ include "analytics.fullname" . }}-vector-config
+      {{- with $webapp.extraVolumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+
+{{- end }}

--- a/analytics/templates/vector/vector-service.yaml
+++ b/analytics/templates/vector/vector-service.yaml
@@ -1,0 +1,27 @@
+{{- $webapp := .Values.vector -}}
+{{- if $webapp.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "analytics.fullname" . }}-vector-svc
+  labels:
+    {{- include "analytics.labels" . | nindent 4 }}
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-vector
+spec:
+  ports:
+    - name: grpc
+      port: 4317
+      targetPort: grpc
+      protocol: TCP
+    - name: http
+      port: 4318
+      targetPort: http
+      protocol: TCP
+    - name: api
+      port: 8686
+      targetPort: api
+      protocol: TCP
+  selector:
+    app.kubernetes.io/component: {{ include "analytics.fullname" . }}-vector
+
+{{- end }}

--- a/analytics/values.yaml
+++ b/analytics/values.yaml
@@ -186,8 +186,8 @@ syncDashboards:
       cpu: 100m
       memory: 128Mi
     limits:
-      cpu: 500m
-      memory: 256Mi
+      cpu: 1000m
+      memory: 1512Mi
   # podSecurityContext is the pod-level security context.
   podSecurityContext:
     runAsNonRoot: true

--- a/analytics/values.yaml
+++ b/analytics/values.yaml
@@ -18,7 +18,7 @@ timescaledb:
     # repository is the TimescaleDB container image repository.
     repository: timescale/timescaledb
     # tag is the TimescaleDB container image tag.
-    tag: 2.26.1-pg18-oss
+    tag: 2.26.1-pg18
     # pullPolicy is the image pull policy.
     pullPolicy: IfNotPresent
   auth:

--- a/analytics/values.yaml
+++ b/analytics/values.yaml
@@ -16,9 +16,9 @@ timescaledb:
   timezone: "Europe/Paris"
   image:
     # repository is the TimescaleDB container image repository.
-    repository: timescale/timescaledb-ha
+    repository: timescale/timescaledb
     # tag is the TimescaleDB container image tag.
-    tag: pg18.3-ts2.26.1-oss
+    tag: 2.26.1-pg18-oss
     # pullPolicy is the image pull policy.
     pullPolicy: IfNotPresent
   auth:

--- a/analytics/values.yaml
+++ b/analytics/values.yaml
@@ -65,9 +65,14 @@ timescaledb:
       cpu: "1"
       memory: 2Gi
   # podSecurityContext is the pod-level security context.
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 70
+    runAsGroup: 70
+    fsGroup: 70
   # securityContext is the container-level security context.
-  securityContext: {}
+  securityContext:
+    runAsUser: 70
   # nodeSelector is the node selector for pod scheduling.
   nodeSelector: {}
   # tolerations is the tolerations for pod scheduling.
@@ -106,9 +111,14 @@ vector:
       cpu: 500m
       memory: 512Mi
   # podSecurityContext is the pod-level security context.
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 65534
+    runAsGroup: 65534
+    fsGroup: 65534
   # securityContext is the container-level security context.
-  securityContext: {}
+  securityContext:
+    runAsUser: 65534
   # nodeSelector is the node selector for pod scheduling.
   nodeSelector: {}
   # tolerations is the tolerations for pod scheduling.
@@ -178,9 +188,14 @@ cli:
       cpu: 500m
       memory: 512Mi
   # podSecurityContext is the pod-level security context.
-  podSecurityContext: {}
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    runAsGroup: 10001
+    fsGroup: 10001
   # securityContext is the container-level security context.
-  securityContext: {}
+  securityContext:
+    runAsUser: 10000
   # nodeSelector is the node selector for pod scheduling.
   nodeSelector: {}
   # tolerations is the tolerations for pod scheduling.

--- a/analytics/values.yaml
+++ b/analytics/values.yaml
@@ -154,6 +154,72 @@ vector:
           - gw_access_logs_filter
         source: "."
 
+# syncDashboards is the Job that syncs Superset dashboards on install/upgrade.
+syncDashboards:
+  # enabled is whether to run the sync-dashboards job.
+  enabled: true
+  # useHelmHooks controls whether the job uses Helm hooks (post-install/post-upgrade).
+  # Set to false when using ArgoCD, Flux, Rancher or Terraform.
+  useHelmHooks: true
+  # jobAnnotations is additional annotations for the job (used when useHelmHooks is false).
+  # For ArgoCD, uncomment the following to run the job on every sync:
+  #   argocd.argoproj.io/hook: Sync
+  jobAnnotations: {}
+  # backoffLimit is the number of retries before marking the job as failed.
+  backoffLimit: 1
+  # ttlSecondsAfterFinished is the TTL for the job after completion.
+  ttlSecondsAfterFinished: 300
+  image:
+    # repository is the sync-dashboards container image repository.
+    repository: georchestra/analytics-syncdashboards
+    # tag is the sync-dashboards container image tag.
+    tag: sha-05df948
+    # pullPolicy is the image pull policy.
+    pullPolicy: IfNotPresent
+  # supersetUrl is the URL of the Superset instance.
+  supersetUrl: "http://superset:8888"
+  # args is the additional arguments to pass to the sync_dashboards.py script.
+  args: []
+  # resources is the resource requests and limits for the container.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  # podSecurityContext is the pod-level security context.
+  podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 10000
+    runAsGroup: 10001
+    fsGroup: 10001
+  # securityContext is the container-level security context.
+  securityContext:
+    runAsUser: 10000
+  # nodeSelector is the node selector for pod scheduling.
+  nodeSelector: {}
+  # tolerations is the tolerations for pod scheduling.
+  tolerations: []
+  # affinity is the affinity rules for pod scheduling.
+  affinity: {}
+  # podAnnotations is the annotations to add to the pod.
+  podAnnotations: {}
+  # extraEnv is additional environment variables for the container.
+  # Example for classic auth instead of geOrchestra sec-headers:
+  #   - name: SUPERSET_USERNAME
+  #     value: admin
+  #   - name: SUPERSET_PASSWORD
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: superset-secret
+  #         key: password
+  extraEnv: []
+  # extraVolumes is additional volumes for the pod.
+  extraVolumes: []
+  # extraVolumeMounts is additional volume mounts for the container.
+  extraVolumeMounts: []
+
 # cli is the Python CLI CronJob configuration.
 cli:
   # enabled is whether to deploy the CLI CronJob.
@@ -164,9 +230,9 @@ cli:
     # repository is the CLI container image repository.
     repository: georchestra/analytics-cli
     # tag is the CLI container image tag.
-    tag: latest
+    tag: 2.0.0
     # pullPolicy is the image pull policy.
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   fakeRecords:
     # enabled is whether to generate fake log records instead of processing real ones.
     # Useful for dashboard development.

--- a/analytics/values.yaml
+++ b/analytics/values.yaml
@@ -159,7 +159,7 @@ cli:
   # enabled is whether to deploy the CLI CronJob.
   enabled: true
   # schedule is the cron schedule for the CLI CronJob.
-  schedule: "0 01 * * *"
+  schedule: "0 * * * *"
   image:
     # repository is the CLI container image repository.
     repository: georchestra/analytics-cli

--- a/analytics/values.yaml
+++ b/analytics/values.yaml
@@ -16,9 +16,9 @@ timescaledb:
   timezone: "Europe/Paris"
   image:
     # repository is the TimescaleDB container image repository.
-    repository: timescale/timescaledb
+    repository: timescale/timescaledb-ha
     # tag is the TimescaleDB container image tag.
-    tag: 2.26.1-pg17
+    tag: pg18.3-ts2.26.1-oss
     # pullPolicy is the image pull policy.
     pullPolicy: IfNotPresent
   auth:

--- a/analytics/values.yaml
+++ b/analytics/values.yaml
@@ -1,0 +1,242 @@
+# Default values for analytics.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# imagePullSecrets is the list of image pull secrets for private registries.
+imagePullSecrets: []
+# nameOverride is the override for the chart name.
+nameOverride: ""
+# fullnameOverride is the override for the fully qualified app name.
+fullnameOverride: ""
+
+timescaledb:
+  # builtin is whether to deploy the built-in TimescaleDB instance.
+  builtin: true
+  # timezone is the timezone for the TimescaleDB instance.
+  timezone: "Europe/Paris"
+  image:
+    # repository is the TimescaleDB container image repository.
+    repository: timescale/timescaledb
+    # tag is the TimescaleDB container image tag.
+    tag: 2.26.1-pg17
+    # pullPolicy is the image pull policy.
+    pullPolicy: IfNotPresent
+  auth:
+    # existingSecret is the name of an existing secret containing database credentials.
+    # If set, it will replace the auth settings below.
+    # existingSecret: my-existing-secret
+    # database is the name of the database to create.
+    database: analytics
+    # username is the database username.
+    username: tsdb
+    # password is the database password.
+    password: secret
+    # port is the database port.
+    port: "5432"
+    # existingEnvSecret is the name of an existing secret containing TSDB_OTEL_TABLE and any other
+    # non-connection environment variables. If set, the auto-generated timescaledb-env-secret
+    # will not be created.
+    # existingEnvSecret: my-timescaledb-env-secret
+  # dbOpentelemetryTable is the name of the OpenTelemetry buffer table.
+  dbOpentelemetryTable: "analytics.opentelemetry_buffer"
+  persistence:
+    # annotations is the annotations for the PVC.
+    annotations:
+      helm.sh/resource-policy: keep
+    # size is the size of the persistent volume.
+    size: 100Gi
+    # accessModes is the access modes for the persistent volume.
+    accessModes:
+      - ReadWriteOnce
+    ## storageClass is the storage class for the persistent volume.
+    ## If defined, storageClassName: <storageClass>
+    ## If set to "-", storageClassName: "", which disables dynamic provisioning
+    ## If undefined (the default) or set to null, no storageClassName spec is
+    ##   set, choosing the default provisioner.
+    # storageClass: ""
+    ## existingPV is the name of an existing PersistentVolume to bind to.
+    # existingPV: timescaledb-data
+  # resources is the resource requests and limits for the TimescaleDB container.
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+    limits:
+      cpu: "1"
+      memory: 2Gi
+  # podSecurityContext is the pod-level security context.
+  podSecurityContext: {}
+  # securityContext is the container-level security context.
+  securityContext: {}
+  # nodeSelector is the node selector for pod scheduling.
+  nodeSelector: {}
+  # tolerations is the tolerations for pod scheduling.
+  tolerations: []
+  # affinity is the affinity rules for pod scheduling.
+  affinity: {}
+  # podAnnotations is the annotations to add to the pod.
+  podAnnotations: {}
+  # lifecycle is the lifecycle hooks for the container.
+  lifecycle: {}
+  # extraEnv is additional environment variables for the container.
+  extraEnv: []
+  # extraVolumes is additional volumes for the pod.
+  extraVolumes: []
+  # extraVolumeMounts is additional volume mounts for the container.
+  extraVolumeMounts: []
+
+vector:
+  # enabled is whether to deploy the Vector instance.
+  enabled: true
+  # replicaCount is the number of Vector replicas.
+  replicaCount: 1
+  image:
+    # repository is the Vector container image repository.
+    repository: timberio/vector
+    # tag is the Vector container image tag.
+    tag: 0.50.0-alpine
+    # pullPolicy is the image pull policy.
+    pullPolicy: IfNotPresent
+  # resources is the resource requests and limits for the Vector container.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  # podSecurityContext is the pod-level security context.
+  podSecurityContext: {}
+  # securityContext is the container-level security context.
+  securityContext: {}
+  # nodeSelector is the node selector for pod scheduling.
+  nodeSelector: {}
+  # tolerations is the tolerations for pod scheduling.
+  tolerations: []
+  # affinity is the affinity rules for pod scheduling.
+  affinity: {}
+  # podAnnotations is the annotations to add to the pod.
+  podAnnotations: {}
+  # lifecycle is the lifecycle hooks for the container.
+  lifecycle: {}
+  # extraEnv is additional environment variables for the container.
+  extraEnv: []
+  # extraVolumes is additional volumes for the pod.
+  extraVolumes: []
+  # extraVolumeMounts is additional volume mounts for the container.
+  extraVolumeMounts: []
+
+  # config is the Vector custom configuration (merged with the hardcoded default).
+  config:
+    # transforms is the Vector transforms configuration.
+    # Must include a "tsdb_input" transform as the bridge to the default tsdb sink.
+    transforms:
+      gw_access_logs_filter:
+        type: filter
+        inputs:
+          - opentelemetry.logs
+        condition:
+          type: "vrl"
+          source: '.scope.name == "org.georchestra.gateway.accesslog"'
+      tsdb_input:
+        type: remap
+        inputs:
+          - gw_access_logs_filter
+        source: "."
+
+# cli is the Python CLI CronJob configuration.
+cli:
+  # enabled is whether to deploy the CLI CronJob.
+  enabled: true
+  # schedule is the cron schedule for the CLI CronJob.
+  schedule: "0 01 * * *"
+  image:
+    # repository is the CLI container image repository.
+    repository: georchestra/analytics-cli
+    # tag is the CLI container image tag.
+    tag: latest
+    # pullPolicy is the image pull policy.
+    pullPolicy: Always
+  fakeRecords:
+    # enabled is whether to generate fake log records instead of processing real ones.
+    # Useful for dashboard development.
+    # Beware that when this is active, it will not process the real records, only generate fake ones.
+    enabled: false
+    # coverDurationHours defines how many hours before now will be covered.
+    # You will want to make it match with the schedule.
+    # For instance, with coverDurationHours: 1 and schedule: "01 * * * *", it will generate every hour
+    # records for the last hour (ensuring you don't have any gaps in your data).
+    coverDurationHours: 1
+    # maxRate is the max number of records per hour.
+    maxRate: 50
+  # resources is the resource requests and limits for the CLI container.
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 500m
+      memory: 512Mi
+  # podSecurityContext is the pod-level security context.
+  podSecurityContext: {}
+  # securityContext is the container-level security context.
+  securityContext: {}
+  # nodeSelector is the node selector for pod scheduling.
+  nodeSelector: {}
+  # tolerations is the tolerations for pod scheduling.
+  tolerations: []
+  # affinity is the affinity rules for pod scheduling.
+  affinity: {}
+  # podAnnotations is the annotations to add to the pod.
+  podAnnotations: {}
+  # extraEnv is additional environment variables for the container.
+  extraEnv: []
+  # extraVolumes is additional volumes for the pod.
+  extraVolumes: []
+  # extraVolumeMounts is additional volume mounts for the container.
+  extraVolumeMounts: []
+  # config is the CLI application configuration.
+  config:
+    # performance is the batch processing configuration.
+    performance:
+      # batchSize is the number of records per batch.
+      batchSize: 10000
+    # appsMapping is the custom application name mappings.
+    appsMapping: {}
+    # timezone is the local timezone for time-related handling.
+    timezone: "Europe/Paris"
+    # parsers is the log parser configuration (kept as a literal block to preserve regex strings).
+    parsers: |-
+      opentelemetry:
+        text_message_parser:
+          enable: false
+          regex: r"^(?P<ip>[0-9a-fA-F:\.]+) (?P<user_identifier>[-_\w]+) (?P<user>[-_\|, \w]+) \[(?P<timestamp>.*)\] \"(?P<method>GET|POST|HEAD|OPTION|PUT|PATCH|DELETE|TRACE|CONNECT) (https?:\/\/[_:a-zA-Z0-9\.-]+)?(?P<path>\/(?P<app>[_a-zA-Z0-9-]+)(\/.*)) HTTP\/[\.0-9]{3}\" (?P<status_code>[0-9]{3}) (?P<response_size>[-0-9]*)"
+      text_message:
+        regex: '^(?P<ip>[0-9a-fA-F:\.]+) (?P<user_identifier>[-_\w]+) (?P<user>[-_\|, \w]+) \[(?P<timestamp>.*)\] \"(?P<method>GET|POST|HEAD|OPTION|PUT|PATCH|DELETE|TRACE|CONNECT) (https?:\/\/[_:a-zA-Z0-9\.-]+)?(?P<path>\/(?P<app>[_a-zA-Z0-9-]+)(\/.*)) HTTP\/[\.0-9]{3}\" (?P<status_code>[0-9]{3}) (?P<response_size>[-0-9]*) \"-\" \"(?P<user_agent>[-0-9a-zA-Z\/\.: ();_]*)\" (?P<misc>.*) (?P<response_time>[0-9]+)ms$'
+    # metrics is the Prometheus metrics export configuration.
+    metrics:
+      # enabled is whether to enable metrics collection.
+      enabled: true
+      # metrics_file_path is the file path to write Prometheus metrics to.
+      # metrics_file_path: /tmp/analytics.prom
+      # pushgateway_url is the Prometheus Pushgateway URL to push metrics to.
+      # pushgateway_url: localhost:9091
+    # logging is the Python logging configuration.
+    logging:
+      version: 1
+      root:
+        handlers: [console]
+        level: DEBUG
+      handlers:
+        console:
+          class: logging.StreamHandler
+          formatter: default
+      formatters:
+        default:
+          format: '%(asctime)s %(levelname)-8s %(name)-15s %(message)s'
+          datefmt: '%Y-%m-%d %H:%M:%S'
+      loggers:
+        georchestra_analytics_cli:
+          level: DEBUG
+        __main__:
+          level: DEBUG

--- a/georchestra/templates/gateway/gateway-deployment.yaml
+++ b/georchestra/templates/gateway/gateway-deployment.yaml
@@ -46,6 +46,22 @@ spec:
           {{- if .Values.rabbitmq.enabled -}}
           {{- include "georchestra.rabbitmq-georchestra-envs" . | nindent 10 }}
           {{- end }}
+          {{- if $webapp.analytics.enabled }}
+          - name: OTEL_JAVAAGENT_ENABLED
+            value: "true"
+          - name: OTEL_EXPORTER_OTLP_PROTOCOL
+            value: "grpc"
+          - name: OTEL_EXPORTER_OTLP_ENDPOINT
+            value: {{ $webapp.analytics.otlp_endpoint | quote }}
+          - name: OTEL_INSTRUMENTATION_LOGBACK_APPENDER_EXPERIMENTAL_CAPTURE_MDC_ATTRIBUTES
+            value: "*"
+          - name: OTEL_TRACES_EXPORTER
+            value: "none"
+          - name: OTEL_METRICS_EXPORTER
+            value: "none"
+          - name: OTEL_LOGS_EXPORTER
+            value: "otlp"
+          {{- end }}
           {{- if $webapp.extra_environment }}
           {{- $webapp.extra_environment | toYaml | nindent 10 }}
           {{- end }}

--- a/georchestra/values.yaml
+++ b/georchestra/values.yaml
@@ -346,6 +346,9 @@ georchestra:
       environment:
         JAVA_TOOL_OPTIONS: "-Dgeorchestra.datadir=/etc/georchestra"
       extra_environment: []
+      analytics:
+        enabled: false
+        otlp_endpoint: "http://analytics-vector-svc:4317"
       service:
         annotations: {}
       tolerations: []


### PR DESCRIPTION
Move the helm chart manifests from Analytics to a dedicated helm chart project.

https://github.com/georchestra/analytics

What this all brings:
- Use helm best practices: https://helm.sh/docs/chart_best_practices/values/
- Add more useful parameters like tolerations, affinity, podAnnotations and more.
- For vector, have a default config and a custom config. A default config in the helm manifests and a custom config available through the values.yaml
- For vector and CLI config, put that available directly as YAML in the values.yaml.
- Set limits and requests by default.
- Automatic restart on configmap change.