### PR TITLE
feat(storage): allow custom labels and annotations on PVCs

### DIFF
--- a/georchestra/README.md
+++ b/georchestra/README.md
@@ -138,7 +138,27 @@ georchestra:
       # storage_class_name: my-storage-class
       # pv_name: my-existing-pv
       # existingClaim: my-existing-pvc
+      # labels:
+      #   velero.io/exclude-from-backup: "true"
+      # annotations:
+      #   example.com/owner: gis-team
 ```
+
+Each storage entry also accepts optional `labels` and `annotations` maps that are
+applied to the generated PVC's `metadata`. They are merged with the chart's
+default labels — user-supplied keys win on conflict. The most common use is
+labelling a PVC so backup tools (e.g. Velero) skip its volume data:
+
+```yaml
+georchestra:
+  storage:
+    geoserver_geodata:
+      size: 2Gi
+      labels:
+        velero.io/exclude-from-backup: "true"
+```
+
+The same `labels` / `annotations` keys are supported under `rabbitmq.storage`.
 
 ### Database
 

--- a/georchestra/templates/geonetwork/elasticsearch/es-data-pvc.yaml
+++ b/georchestra/templates/geonetwork/elasticsearch/es-data-pvc.yaml
@@ -6,10 +6,17 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.storage.claimName" (list . "gn4_es") }}-data
+  {{- with $webapp_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-gn4-elasticsearch
     helm.sh/resource-policy: "keep"
+    {{- with $webapp_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $webapp_storage.accessModes }}

--- a/georchestra/templates/geonetwork/geonetwork-datadir-pvc.yaml
+++ b/georchestra/templates/geonetwork/geonetwork-datadir-pvc.yaml
@@ -5,10 +5,17 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.storage.claimName" (list . "geonetwork_datadir") }}
+  {{- with $webapp_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geonetwork
     helm.sh/resource-policy: "keep"
+    {{- with $webapp_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $webapp_storage.accessModes }}

--- a/georchestra/templates/geoserver/geoserver-datadir-pvc.yaml
+++ b/georchestra/templates/geoserver/geoserver-datadir-pvc.yaml
@@ -5,10 +5,17 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.storage.claimName" (list . "geoserver_datadir") }}
+  {{- with $webapp_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geoserver
     helm.sh/resource-policy: "keep"
+    {{- with $webapp_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $webapp_storage.accessModes }}

--- a/georchestra/templates/geoserver/geoserver-geodata-pvc.yaml
+++ b/georchestra/templates/geoserver/geoserver-geodata-pvc.yaml
@@ -5,10 +5,17 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.storage.claimName" (list . "geoserver_geodata") }}
+  {{- with $webapp_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geoserver
     helm.sh/resource-policy: "keep"
+    {{- with $webapp_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $webapp_storage.accessModes }}

--- a/georchestra/templates/geoserver/geoserver-tiles-pvc.yaml
+++ b/georchestra/templates/geoserver/geoserver-tiles-pvc.yaml
@@ -5,10 +5,17 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.storage.claimName" (list . "geoserver_tiles") }}
+  {{- with $webapp_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geoserver
     helm.sh/resource-policy: "keep"
+    {{- with $webapp_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $webapp_storage.accessModes }}

--- a/georchestra/templates/geowebcache/geowebcache-tiles-pvc.yaml
+++ b/georchestra/templates/geowebcache/geowebcache-tiles-pvc.yaml
@@ -5,10 +5,17 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.storage.claimName" (list . "geowebcache_tiles") }}
+  {{- with $webapp_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-geowebcache
     helm.sh/resource-policy: "keep"
+    {{- with $webapp_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $webapp_storage.accessModes }}

--- a/georchestra/templates/ldap/openldap-pvc-config.yaml
+++ b/georchestra/templates/ldap/openldap-pvc-config.yaml
@@ -5,10 +5,17 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.storage.claimName" (list . "openldap_config") }}
+  {{- with $webapp_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-ldap
     helm.sh/resource-policy: "keep"
+    {{- with $webapp_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $webapp_storage.accessModes }}

--- a/georchestra/templates/ldap/openldap-pvc-data.yaml
+++ b/georchestra/templates/ldap/openldap-pvc-data.yaml
@@ -5,10 +5,17 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.storage.claimName" (list . "openldap_data") }}
+  {{- with $webapp_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-ldap
     helm.sh/resource-policy: "keep"
+    {{- with $webapp_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $webapp_storage.accessModes }}

--- a/georchestra/templates/mapstore/mapstore-pvc.yaml
+++ b/georchestra/templates/mapstore/mapstore-pvc.yaml
@@ -5,10 +5,17 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.storage.claimName" (list . "mapstore_datadir") }}
+  {{- with $webapp_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-mapstore
     helm.sh/resource-policy: "keep"
+    {{- with $webapp_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $webapp_storage.accessModes }}

--- a/georchestra/templates/rabbitmq/rabbitmq-pvc.yaml
+++ b/georchestra/templates/rabbitmq/rabbitmq-pvc.yaml
@@ -5,9 +5,16 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "georchestra.fullname" . }}-rabbitmq
+  {{- with $rabbitmq_storage.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "georchestra.labels" . | nindent 4 }}
     app.kubernetes.io/component: {{ include "georchestra.fullname" . }}-rabbitmq
+    {{- with $rabbitmq_storage.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   accessModes:
   {{- if $rabbitmq_storage.accessModes }}

--- a/georchestra/values.yaml
+++ b/georchestra/values.yaml
@@ -383,6 +383,10 @@ georchestra:
     #   storage_class_name: default or "-" for empty storageClassName
     #   accessModes: Optional - If set will override the general value for this storage
     #   - ReadWriteOnce|ReadOnlyMany|ReadWriteMany
+    #   labels: Optional - Map of extra labels to apply to the generated PVC
+    #     (e.g. velero.io/exclude-from-backup: "true" to skip filesystem backup).
+    #     Merged on top of chart defaults; user keys win on conflict.
+    #   annotations: Optional - Map of extra annotations to apply to the generated PVC.
     gn4_es:
       size: 2Gi
     geonetwork_datadir:
@@ -580,6 +584,8 @@ rabbitmq:
   storage:
     # pv_name: rabbitmq-data  # Optional: name of existing PV to bind to
     # storage_class_name: default  # Optional: storage class name
+    # labels: {}        # Optional: extra labels merged onto the PVC (user keys win)
+    # annotations: {}   # Optional: annotations applied to the PVC
     accessModes:
     - ReadWriteOnce
     size: 1Gi


### PR DESCRIPTION
Each storage entry now accepts optional `labels` and `annotations` maps that are merged onto the generated PVC's metadata. The motivating use case is letting users tag specific volumes with
`velero.io/exclude-from-backup: "true"` to skip filesystem backups, but the keys are generic. Chart-default labels are preserved; user keys win on conflict.