### PR TITLE
chore: remove geoserver sandbox env [GSEST-894]

### DIFF
--- a/georchestra/values.yaml
+++ b/georchestra/values.yaml
@@ -220,10 +220,6 @@ georchestra:
       # container extra volume. It should match an item from the extra_volumes.name
       # variable above.
       extra_volumeMounts: []
-      environment:
-        # Filesystem sandbox restricts access to one particular directory
-        # See: https://docs.geoserver.org/main/en/user/security/sandbox.html
-        GEOSERVER_FILESYSTEM_SANDBOX: "/mnt/geoserver_geodata"
       tolerations: []
       # registry_secret: default
       service:


### PR DESCRIPTION
Remove this env since it is now handled inside the Docker image directly: https://github.com/georchestra/geoserver/blob/eafd8850da9c334ccecdbdf8934dab40b0a5f7f2/webapp/src/docker/Dockerfile#L44