### PR TITLE
fix: volume mount timescaledb under /var/lib/postgresql

### DIFF
--- a/analytics/Chart.yaml
+++ b/analytics/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.5
+version: 1.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/analytics/templates/timescaledb/timescaledb-deployment.yaml
+++ b/analytics/templates/timescaledb/timescaledb-deployment.yaml
@@ -79,7 +79,7 @@ spec:
             {{- toYaml . | nindent 12 }}
             {{- end }}
           volumeMounts:
-            - mountPath: /home/postgres/pgdata
+            - mountPath: /var/lib/postgresql
               name: timescaledb-data
             - mountPath: /docker-entrypoint-initdb.d/100_analytics_init.sql
               name: timescaledb-initscripts


### PR DESCRIPTION
Since it depends of which image will be used for the deployment, makes the path where postgresql will actually store datas configureable.

tests: only "statically" using `helm template .`