### PR TITLE
feat: helm chart http-proxy

### DIFF
--- a/http-proxy/Chart.yaml
+++ b/http-proxy/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: http-proxy
+description: A Helm chart for geOrchestra http-proxy
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.5.0"

--- a/http-proxy/README.md
+++ b/http-proxy/README.md
@@ -1,0 +1,20 @@
+# http-proxy
+
+Helm chart for geOrchestra http-proxy: https://github.com/georchestra/http-proxy
+
+Runs the proxy as a standalone fat JAR (embedded Jetty) using the
+`georchestra/http-proxy:latest` Docker image introduced in
+https://github.com/georchestra/http-proxy/pull/1.
+
+## Configuration
+
+The proxy reads its configuration from a properties file whose path is
+defined by the `PROXY_PROP_PATH` environment variable. The chart renders
+`values.configMap.proxyProperties` into a `ConfigMap` and mounts it at
+`/config/proxy.properties`.
+
+## Network policies
+
+Set `networkPolicy.enabled=true` to apply the bundled `NetworkPolicy`.
+Override `networkPolicy.ingress` and `networkPolicy.egress` to match the
+clients and upstream hosts the proxy must reach in your cluster.

--- a/http-proxy/templates/_helpers.tpl
+++ b/http-proxy/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "http-proxy.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "http-proxy.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "http-proxy.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "http-proxy.labels" -}}
+helm.sh/chart: {{ include "http-proxy.chart" . }}
+{{ include "http-proxy.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "http-proxy.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "http-proxy.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/http-proxy/templates/configmap.yaml
+++ b/http-proxy/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "http-proxy.fullname" . }}
+  labels:
+    {{- include "http-proxy.labels" . | nindent 4 }}
+data:
+  proxy.properties: |
+{{ .Values.configMap.proxyProperties | indent 4 }}

--- a/http-proxy/templates/deployment.yaml
+++ b/http-proxy/templates/deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "http-proxy.fullname" . }}
+  labels:
+    {{- include "http-proxy.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "http-proxy.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "http-proxy.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- $defaultEnv := dict "PORT" (.Values.service.port | toString) "PROXY_PROP_PATH" "/config/proxy.properties" }}
+            {{- range $key, $value := merge (default (dict) .Values.env) $defaultEnv }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: proxy-config
+              mountPath: /config/proxy.properties
+              subPath: proxy.properties
+              readOnly: true
+            {{- with .Values.volumeMounts }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+      volumes:
+        - name: proxy-config
+          configMap:
+            name: {{ include "http-proxy.fullname" . }}
+        {{- with .Values.volumes }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/http-proxy/templates/networkpolicy.yaml
+++ b/http-proxy/templates/networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicy.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "http-proxy.fullname" . }}
+  labels:
+    {{- include "http-proxy.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "http-proxy.selectorLabels" . | nindent 6 }}
+  policyTypes:
+  {{- if .Values.networkPolicy.ingress }}
+    - Ingress
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+    - Egress
+  {{- end }}
+  {{- with .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/http-proxy/templates/service.yaml
+++ b/http-proxy/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "http-proxy.fullname" . }}
+  labels:
+    {{- include "http-proxy.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "http-proxy.selectorLabels" . | nindent 4 }}

--- a/http-proxy/values.yaml
+++ b/http-proxy/values.yaml
@@ -1,0 +1,136 @@
+replicaCount: 1
+
+image:
+  repository: georchestra/http-proxy
+  pullPolicy: IfNotPresent
+  tag: "1.5.0-0"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65532
+
+# Extra environment variables as a key/value map. Merged with the chart's
+# built-in env (PORT, PROXY_PROP_PATH); keys defined here take precedence.
+env: {}
+  # JAVA_OPTS: "-Xmx256m"
+  # SOME_OTHER_VAR: "value"
+
+# Contents of the proxy.properties file rendered into a ConfigMap and
+# mounted at /config/proxy.properties (referenced via PROXY_PROP_PATH).
+# See https://github.com/georchestra/http-proxy for the available keys.
+configMap:
+  proxyProperties: |
+    # geOrchestra http-proxy configuration
+    # List of allowed target hosts (comma separated, regex or literals).
+    # proxyHostsWhitelist=
+    # Methods allowed to pass through the proxy.
+    # methodsWhitelist=GET,POST,HEAD,OPTIONS
+    # Mimetype whitelist applied to responses.
+    # mimetypesWhitelist=
+    # Maximum file upload size in bytes.
+    # maxFileUploadSize=
+    # Connection / read timeout, in milliseconds.
+    # connectionTimeout=
+    # soTimeout=
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources: {}
+  # limits:
+  #   cpu: 500m
+  #   memory: 512Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 256Mi
+
+livenessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 30
+readinessProbe:
+  tcpSocket:
+    port: http
+  initialDelaySeconds: 10
+  periodSeconds: 10
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# Network policies applied to the proxy pod.
+# Egress is restricted to public internet IP ranges only: traffic to RFC1918
+# (10/8, 172.16/12, 192.168/16), CGNAT (100.64/10), link-local (169.254/16,
+# fe80::/10), loopback (127/8, ::1/128), unique local (fc00::/7) and
+# multicast ranges is denied. DNS resolution is allowed against kube-dns so
+# hostnames can still be resolved.
+networkPolicy:
+  enabled: true
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: georchestra-gateway
+      ports:
+        - protocol: TCP
+          port: 8080
+  egress:
+    # DNS to kube-dns (internal, allowed by exception so the proxy can resolve hostnames)
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Public internet only — block private/internal ranges
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 10.0.0.0/8
+              - 172.16.0.0/12
+              - 192.168.0.0/16
+              - 100.64.0.0/10
+              - 169.254.0.0/16
+              - 127.0.0.0/8
+              - 224.0.0.0/4
+        - ipBlock:
+            cidr: ::/0
+            except:
+              - fc00::/7
+              - fe80::/10
+              - ::1/128
+              - ff00::/8
+      ports:
+        - protocol: TCP
+          port: 80
+        - protocol: TCP
+          port: 443


### PR DESCRIPTION
Creating helm chart for https://github.com/georchestra/http-proxy/pull/1

For deploying https://hub.docker.com/r/georchestra/http-proxy There are network policies by default that for security:
- Restrict outgoing traffic only to the Internet.
- Restrict incoming traffic from geOrchestra gateway only.